### PR TITLE
fix guzzle object to string conversion error

### DIFF
--- a/src/Traits/PayPalRequest.php
+++ b/src/Traits/PayPalRequest.php
@@ -165,7 +165,7 @@ trait PayPalRequest
         } catch (BadResponseException $e) {
             throw new \Exception($e->getRequest() . " " . $e->getResponse());
         } catch (\Exception $e) {
-            $message = $e->getRequest(). " " . $e->getResponse();
+            $message = $e->getMessage();
         }
 
         return [


### PR DESCRIPTION
Fix for Error : GuzzleHttp\Psr7\Request could not be converted to string