### PR TITLE
Force SSL TLS v1.2 because PayPal require it.

### DIFF
--- a/src/Traits/PayPalRequest.php
+++ b/src/Traits/PayPalRequest.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Exception\ServerException;
 
 trait PayPalRequest
 {
-    
+
     /**
      * @var Client
      */
@@ -68,7 +68,11 @@ trait PayPalRequest
      */
     protected function setClient()
     {
-        return new Client;
+        return new Client([
+            'curl' => [
+                CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1_2
+            ]
+        ]);
     }
 
     /**


### PR DESCRIPTION
Hello,

as you can see here: https://devblog.paypal.com/upcoming-security-changes-notice/

PayPal is forcing users to use TLS 1.2, I was trying to integrate your plugin to my project, but got strange error "Undefined index: payKey".

When I looked into your code I found that connection to PayPal servers is refused because of bad TLS version.