### PR TITLE
force locale to change gateway language (express checkout)

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -24,4 +24,5 @@ return [
     'payment_action' => 'Sale', // Can Only Be 'Sale', 'Authorization', 'Order'
     'currency'       => 'USD',
     'notify_url'     => '', // Change this accordingly for your application.
+    'locale'         => '', // force gateway language  i.e. it_IT, es_ES, en_US ... (for express checkout only)
 ];

--- a/src/Services/ExpressCheckout.php
+++ b/src/Services/ExpressCheckout.php
@@ -63,6 +63,10 @@ class ExpressCheckout
                 $data['subscription_desc'] : $data['invoice_description'];
         }
 
+        if (!empty($this->config['locale'])) {
+            $post['LOCALECODE'] = $this->config['locale'];
+        }
+        
         foreach ($tmp as $k => $v) {
             $post[$k] = $v;
         }

--- a/src/Services/ExpressCheckout.php
+++ b/src/Services/ExpressCheckout.php
@@ -66,7 +66,7 @@ class ExpressCheckout
         if (!empty($this->config['locale'])) {
             $post['LOCALECODE'] = $this->config['locale'];
         }
-        
+
         foreach ($tmp as $k => $v) {
             $post[$k] = $v;
         }

--- a/src/Traits/PayPalRequest.php
+++ b/src/Traits/PayPalRequest.php
@@ -119,6 +119,7 @@ trait PayPalRequest
         // Adding params outside sandbox / live array
         $this->config['payment_action'] = $credentials['payment_action'];
         $this->config['notify_url'] = $credentials['notify_url'];
+        $this->config['locale'] = $credentials['locale'];
     }
 
     /**


### PR DESCRIPTION
if 'locale' config option is filled with a valid and paypal supported locale it force paypal to use given language (at least for landing page)