### PR TITLE
Specify a default quantity of one for when one isn't passed back over

### DIFF
--- a/src/Services/ExpressCheckout.php
+++ b/src/Services/ExpressCheckout.php
@@ -73,9 +73,9 @@ class ExpressCheckout
     {
         return (new Collection($items))->map(function ($item, $num) {
             return [
-                'L_PAYMENTREQUEST_0_NAME' . $num => $item['name'],
-                'L_PAYMENTREQUEST_0_AMT' . $num => $item['price'],
-                'L_PAYMENTREQUEST_0_QTY' . $num => isset($item['qty']) ? $item['qty'] : 1,
+                'L_PAYMENTREQUEST_0_NAME'.$num => $item['name'],
+                'L_PAYMENTREQUEST_0_AMT'.$num => $item['price'],
+                'L_PAYMENTREQUEST_0_QTY'.$num => isset($item['qty']) ? $item['qty'] : 1,
             ];
         })->flatMap(function ($value) {
             return $value;

--- a/src/Services/ExpressCheckout.php
+++ b/src/Services/ExpressCheckout.php
@@ -73,9 +73,9 @@ class ExpressCheckout
     {
         return (new Collection($items))->map(function ($item, $num) {
             return [
-                'L_PAYMENTREQUEST_0_NAME'.$num  => $item['name'],
-                'L_PAYMENTREQUEST_0_AMT'.$num   => $item['price'],
-                'L_PAYMENTREQUEST_0_QTY'.$num   => $item['qty'],
+                'L_PAYMENTREQUEST_0_NAME' . $num => $item['name'],
+                'L_PAYMENTREQUEST_0_AMT' . $num => $item['price'],
+                'L_PAYMENTREQUEST_0_QTY' . $num => isset($item['qty']) ? $item['qty'] : 1,
             ];
         })->flatMap(function ($value) {
             return $value;

--- a/src/Traits/PayPalRequest.php
+++ b/src/Traits/PayPalRequest.php
@@ -327,10 +327,10 @@ trait PayPalRequest
             'METHOD'    => $method,
         ], $this->options);
 
-        $this->post = $this->post->merge($config)
-            ->filter(function ($value, $key) use ($method) {
-                return (($method === 'verifyipn') && ($key === 'METHOD')) ?: $value;
-            });
+        $this->post = $this->post->merge($config);
+    	if ($method === 'verifyipn') {
+            $this->post->forget('METHOD');
+        }
     }
 
     /**

--- a/src/Traits/PayPalRequest.php
+++ b/src/Traits/PayPalRequest.php
@@ -328,7 +328,7 @@ trait PayPalRequest
         ], $this->options);
 
         $this->post = $this->post->merge($config);
-    	if ($method === 'verifyipn') {
+        if ($method === 'verifyipn') {
             $this->post->forget('METHOD');
         }
     }


### PR DESCRIPTION
When getting a recurring payment response it appears that PayPal doesn't send a quantity value back.

In order to stop this throwing an error we need to check if qty is set and if not set a quantity of 1. Once Laravel is >= php7 this piece of code should be replaced with `$item['qty'] ?? 1`