### PR TITLE
Add notify_url to setAdaptivePaymentsOptions method

### DIFF
--- a/src/Services/AdaptivePayments.php
+++ b/src/Services/AdaptivePayments.php
@@ -31,6 +31,7 @@ class AdaptivePayments
             $this->config['api_url'] = 'https://svcs.paypal.com/AdaptivePayments';
             $this->config['gateway_url'] = 'https://www.paypal.com/cgi-bin/webscr';
         }
+        $this->config['notify_url'] = config('paypal.notify_url');
     }
 
     /**


### PR DESCRIPTION
First, thanks for building this awesome package!
There was a change made in 1.5.8 that breaks adaptive payments.
\src\Traits\PayPalRequest.php setApiCredentials()
`$this->notifyUrl = $credentials['notify_url'];`
changed to
`$this->notifyUrl = $this->config['notify_url'];`
but in
\src\Services\AdaptivePayments.php setAdaptivePaymentsOptions()
$this->config['notify_url'] doesn't get set. The call doesn't seems to need a notify_url but because setApiCredentials() is looking for it and it's missing you'll get an error that stops the user from continuing to PayPal.
`ErrorException (E_NOTICE) Undefined index: notify_url`
Please review and let me know if you have any questions. Thanks again!