### PR TITLE
add support for subtotal and shipping information while doing Express…

### DIFF
--- a/src/Services/ExpressCheckout.php
+++ b/src/Services/ExpressCheckout.php
@@ -185,10 +185,12 @@ class ExpressCheckout
      */
     public function doExpressCheckoutPayment($data, $token, $payerid)
     {
+        $this->setItemSubTotal($data);
+
         $this->post = $this->setCartItems($data['items'])->merge([
             'TOKEN'                          => $token,
             'PAYERID'                        => $payerid,
-            'PAYMENTREQUEST_0_ITEMAMT'       => $data['total'],
+            'PAYMENTREQUEST_0_ITEMAMT'       => $this->subtotal,
             'PAYMENTREQUEST_0_AMT'           => $data['total'],
             'PAYMENTREQUEST_0_PAYMENTACTION' => !empty($this->config['payment_action']) ? $this->config['payment_action'] : 'Sale',
             'PAYMENTREQUEST_0_CURRENCYCODE'  => $this->currency,
@@ -196,6 +198,8 @@ class ExpressCheckout
             'PAYMENTREQUEST_0_INVNUM'        => $data['invoice_id'],
             'PAYMENTREQUEST_0_NOTIFYURL'     => $this->notifyUrl,
         ]);
+
+        $this->setShippingAmount($data);
 
         return $this->doPayPalRequest('DoExpressCheckoutPayment');
     }


### PR DESCRIPTION
Hi!

I was just facing errors when doing the Express Checkout. I mean, after doing the checkout in paypal you are redirected to a "success" endpoint of the application and If you have sent shipping and subtotal information while setting the Express Checkout, the "doExpressCheckoutPayment" method was not supporting this information so it fails.

This PR is an effort to solve this, I have tested this in a personal project and is working well with Express Checkout, I don't know if this change has implications in subscriptions, but I think that there would be no problem because is only extra information following with your established methods to add subtotal and shipping.

Hope your'e doing well!

Francisco.