### PR TITLE
Adding the RecurringProfiles::createCustomSubscription method

### DIFF
--- a/src/Traits/RecurringProfiles.php
+++ b/src/Traits/RecurringProfiles.php
@@ -7,6 +7,39 @@ use Carbon\Carbon;
 trait RecurringProfiles
 {
     /**
+     * Create recurring subscription on custom frequency basis.
+     * The billing frequency is in months, i.e: if you want a monthly subscription, then your billing frequency would be 1.
+     *
+     * @param string $token
+     * @param float $amount
+     * @param string $description
+     * @param int $billingFrequency
+     * @param int $trialDays
+     *
+     * @return array
+     */
+    public function createCustomSubscription($token, $amount, $description, $billingFrequency, $trialDays = null)
+    {
+        $data = [
+            'PROFILESTARTDATE' => Carbon::now()->toAtomString(),
+            'DESC'             => $description,
+            'BILLINGPERIOD'    => 'Month',
+            'BILLINGFREQUENCY' => $billingFrequency,
+            'AMT'              => $amount,
+            'CURRENCYCODE'     => $this->currency,
+        ];
+
+        if (!is_null($trialDays) && is_numeric($trialDays)) {
+            $data['TRIALBILLINGPERIOD'] = 'Day';
+            $data['TRIALTOTALBILLINGCYCLES'] = $trialDays;
+            $data['TRIALBILLINGFREQUENCY'] = 1;
+            $data['TRIALAMT'] = 0;
+        }
+
+        return $this->createRecurringPaymentsProfile($data, $token);
+    }
+
+    /**
      * Create recurring subscription on monthly basis.
      *
      * @param string $token


### PR DESCRIPTION
Hi!

I created a new method to create subscription profiles.
It was made thinking about trial periods (now we have the `$trialDays` argument), and custom billing frequencies (now we have the `$billingFrequency`). It is also with the comment doc block.

