### PR TITLE
Bugfix Subscriptions.php

### DIFF
--- a/src/Traits/PayPalAPI/Subscriptions.php
+++ b/src/Traits/PayPalAPI/Subscriptions.php
@@ -168,7 +168,7 @@ trait Subscriptions
             'note'          => $note,
             'capture_type'  => 'OUTSTANDING_BALANCE',
             'amount'        => [
-                'currency'  => $this->currency,
+                'currency_code'  => $this->currency,
                 'value'     => "{$amount}",
             ],
         ];


### PR DESCRIPTION
Paypal is expecting 'currency_code' instead of 'currency' as you can see in their official documentation.
https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_capture