### PR TITLE
Fix: doesn't run setConfig() automatically

### DIFF
--- a/src/Services/PayPal.php
+++ b/src/Services/PayPal.php
@@ -16,7 +16,7 @@ class PayPal
      *
      * @throws Exception
      */
-    public function __construct($config = '')
+    public function __construct($config = [])
     {
         // Setting PayPal API Credentials
         if (is_array($config)) {


### PR DESCRIPTION
I don't really know why the default value for `$config` is a string... 

I was trying to use the package, I tried to initialize the provider using `$paypal = PayPal::setProvider();`
but it gives me an error that says `Trying to access array offset on value of type null`

so a quick check on the package code and I found this and change it to array so it would run...

also to those who are having the same problem as me... you can just initialize the service class directly using 

```php
use Srmklive\PayPal\Services\PayPal;

$paypal = new PayPal([]);
```