### PR TITLE
Add support for Paypal Fraudnet header

### DIFF
--- a/src/Traits/PayPalHttpClient.php
+++ b/src/Traits/PayPalHttpClient.php
@@ -93,7 +93,7 @@ trait PayPalHttpClient
 
             if ($this->fraudnetId) {
                 $options['headers'] = [
-                    'PAYPAL-CLIENT-METADATA-ID' => $this->fraudnetId
+                    'PAYPAL-CLIENT-METADATA-ID' => $this->fraudnetId,
                 ];
             }
 

--- a/src/Traits/PayPalHttpClient.php
+++ b/src/Traits/PayPalHttpClient.php
@@ -87,9 +87,17 @@ trait PayPalHttpClient
     private function makeHttpRequest()
     {
         try {
-            return $this->client->post($this->apiUrl, [
+            $options = [
                 $this->httpBodyParam => $this->post->toArray(),
-            ])->getBody();
+            ];
+
+            if ($this->fraudnetId) {
+                $options['headers'] = [
+                    'PAYPAL-CLIENT-METADATA-ID' => $this->fraudnetId
+                ];
+            }
+
+            return $this->client->post($this->apiUrl, $options)->getBody();
         } catch (Throwable $t) {
             throw new RuntimeException($t->getRequest().' '.$t->getResponse());
         }

--- a/src/Traits/PayPalRequest.php
+++ b/src/Traits/PayPalRequest.php
@@ -127,6 +127,13 @@ trait PayPalRequest
     private $validateSSL;
 
     /**
+     * Fraudnet Header Id
+     *
+     * @var string
+     */
+    private $fraudnetId;
+
+    /**
      * Set PayPal API Credentials.
      *
      * @param array $credentials
@@ -228,6 +235,19 @@ trait PayPalRequest
         $this->apiUrl = $this->config['ipn_url'];
 
         return $this->doPayPalRequest('verifyipn');
+    }
+
+    /**
+     * Function to set fraudnet id.
+     *
+     * @param string $fraudnetId
+     *
+     * @return $this
+     */
+    public function setFraudnetId($fraudnetId)
+    {
+        $this->fraudnetId = $fraudnetId;
+        return $this;
     }
 
     /**

--- a/src/Traits/PayPalRequest.php
+++ b/src/Traits/PayPalRequest.php
@@ -127,7 +127,7 @@ trait PayPalRequest
     private $validateSSL;
 
     /**
-     * Fraudnet Header Id
+     * Fraudnet Header Id.
      *
      * @var string
      */

--- a/src/Traits/PayPalRequest.php
+++ b/src/Traits/PayPalRequest.php
@@ -247,6 +247,7 @@ trait PayPalRequest
     public function setFraudnetId($fraudnetId)
     {
         $this->fraudnetId = $fraudnetId;
+        
         return $this;
     }
 


### PR DESCRIPTION
From Paypal [docs](https://www.paypalobjects.com/webstatic/en_US/developer/docs/pdf/limited-release/PP_LRD_FraudNetIntegrationBasicGuide.pdf)

![image](https://user-images.githubusercontent.com/17528024/121008966-3e5c6400-c79c-11eb-828d-0c853fad6704.png)

