### PR TITLE
Update error responses

### DIFF
--- a/src/Traits/PayPalAPI/CatalogProducts.php
+++ b/src/Traits/PayPalAPI/CatalogProducts.php
@@ -57,8 +57,8 @@ trait CatalogProducts
     /**
      * Update a product.
      *
-     * @param array  $data
      * @param string $product_id
+     * @param array  $data
      *
      * @throws \Throwable
      *
@@ -66,7 +66,7 @@ trait CatalogProducts
      *
      * @see https://developer.paypal.com/docs/api/catalog-products/v1/#products_patch
      */
-    public function updateProduct(array $data, $product_id)
+    public function updateProduct($product_id, array $data)
     {
         $this->apiEndPoint = "v1/catalogs/products/{$product_id}";
         $this->apiUrl = collect([$this->config['api_url'], $this->apiEndPoint])->implode('/');

--- a/src/Traits/PayPalAPI/Subscriptions.php
+++ b/src/Traits/PayPalAPI/Subscriptions.php
@@ -168,8 +168,8 @@ trait Subscriptions
             'note'          => $note,
             'capture_type'  => 'OUTSTANDING_BALANCE',
             'amount'        => [
-                'currency_code'  => $this->currency,
-                'value'     => "{$amount}",
+                'currency_code'     => $this->currency,
+                'value'             => "{$amount}",
             ],
         ];
 

--- a/src/Traits/PayPalHttpClient.php
+++ b/src/Traits/PayPalHttpClient.php
@@ -176,7 +176,7 @@ trait PayPalHttpClient
                 $this->options
             )->getBody();
         } catch (HttpClientException $e) {
-            throw new RuntimeException($e->getRequest()->getBody().' '.$e->getResponse()->getBody());
+            throw new RuntimeException($e->getResponse()->getBody());
         }
     }
 

--- a/src/Traits/PayPalHttpClient.php
+++ b/src/Traits/PayPalHttpClient.php
@@ -197,12 +197,7 @@ trait PayPalHttpClient
 
             return ($decode === false) ? $response->getContents() : \GuzzleHttp\json_decode($response, true);
         } catch (RuntimeException $t) {
-            $message = collect($t->getMessage())->implode('\n');
+            return ($decode === false) ? $t->getMessage() : json_decode('{"error":'.$t->getMessage().'}', true);
         }
-
-        return [
-            'type'    => 'error',
-            'message' => $message,
-        ];
     }
 }

--- a/tests/Feature/AdapterFeatureTest.php
+++ b/tests/Feature/AdapterFeatureTest.php
@@ -37,8 +37,8 @@ class AdapterFeatureTest extends TestCase
         $this->client = new PayPalClient($this->getMockCredentials());
         $response = $this->client->getAccessToken();
 
-        $this->assertArrayHasKey('type', $response);
-        $this->assertEquals('error', $response['type']);
+        $this->assertArrayHasKey('error', $response);
+        $this->assertIsArray($response['error']);
     }
 
     /** @test */

--- a/tests/Feature/AdapterFeatureTest.php
+++ b/tests/Feature/AdapterFeatureTest.php
@@ -249,7 +249,7 @@ class AdapterFeatureTest extends TestCase
 
         $expectedParams = $this->updateProductParams();
 
-        $response = $this->client->updateProduct($expectedParams, self::$product_id);
+        $response = $this->client->updateProduct(self::$product_id, $expectedParams);
 
         $this->assertEmpty($response);
     }

--- a/tests/Unit/Adapter/CatalogProductsTest.php
+++ b/tests/Unit/Adapter/CatalogProductsTest.php
@@ -59,7 +59,7 @@ class CatalogProductsTest extends TestCase
         $mockClient->setApiCredentials($this->getMockCredentials());
         $mockClient->getAccessToken();
 
-        $this->assertEquals($expectedResponse, $mockClient->{$expectedMethod}($expectedParams, '72255d4849af8ed6e0df1173'));
+        $this->assertEquals($expectedResponse, $mockClient->{$expectedMethod}('72255d4849af8ed6e0df1173', $expectedParams));
     }
 
     /** @test */


### PR DESCRIPTION
Hi,

I'm trying to resolve #442 even if the user didn't gave much information, I think I run into the same problem.

It was difficult to deal with Paypal's returning errors because the response was embedded with the request body, returning a wrong JSON string with 2 objects separated by a space. Also the returning array could be simplified.

Here is my attempt to solve the issues.

A couple of notes though :
- I'm not fully aware of the full code, hopefully the request body is not needed anywhere else
- I did not understand why you would make a collection out of the RuntimeException message to implode it right after, since it should already be a JSON string. Does the `collect()` function format the string in a specific way I'm not aware of ? I'm just curious here, I'm still a novice developer and I guess there must be a reason behind it.
- I replaced that collect function directly with a `json_encode()`, preserving your pattern to decode or not the string, and encapsulating the Paypal JSON response in an `error` object for clarity.

PS : I'm just a junior developer, actually I'm still learning and this is my first pull request ever. I'm sorry in advance if that request is not good and any criticism would be much appreciated. Anyway, I really like using your component, it made my life easier with dealing with Paypal. Thanks for bringing it up !