### PR TITLE
Convert boolean to string to fix INVALID_PARAMETER_VALUE for listPlans

### DIFF
--- a/src/Traits/PayPalAPI/BillingPlans.php
+++ b/src/Traits/PayPalAPI/BillingPlans.php
@@ -41,6 +41,8 @@ trait BillingPlans
      */
     public function listPlans(int $page = 1, int $size = 20, bool $totals = true)
     {
+        $totals = ($totals) ? 'true' : 'false';
+
         $this->apiEndPoint = "v1/billing/plans?page={$page}&page_size={$size}&total_required={$totals}";
 
         $this->verb = 'get';


### PR DESCRIPTION
Fixes INVALID_PARAMETER_VALUE error for the v1/billing/plans endpoint. PayPal is looking for a string "true" or "false", but method sends 0/1.

Thanks!