### PR TITLE
remove getAccessToken specific options from service after completed

### DIFF
--- a/src/Traits/PayPalAPI.php
+++ b/src/Traits/PayPalAPI.php
@@ -48,6 +48,8 @@ trait PayPalAPI
         ];
 
         $response = $this->doPayPalRequest();
+        unset($this->options['auth']);
+        unset($this->options[$this->httpBodyParam]);
 
         if (isset($response['access_token'])) {
             $this->setAccessToken($response);


### PR DESCRIPTION
I recently upgraded from 3.0.3 to 3.0.9 and experience a regression in the example code below. I believe this is because the [form_params](https://docs.guzzlephp.org/en/stable/request-options.html#form-params) value persists in the Guzzle configuration after the getAccessToken call is complete.

I also removed the `auth` option, as it is not needed on subsequent requests.

Prior to this patch, I was getting `Your browser sent a request that this server could not understand.` response from PayPal on the indicated line.

Example code:
```
$provider = PayPal::setProvider();
$provider->setApiCredentials(config('paypal-xyz'));
$provider->getAccessToken();
$response = $provider->listPlans(1, 20);
$paypal_plans = collect($response['plans']);
foreach ($paypal_plans as $paypal_plan) {
    $ids[] = $paypal_plan['id'];
    $details = $provider->showPlanDetails($paypal_plan['id']); // Error here.
}
```