### PR TITLE
Add custom methods to create recurring monthly/annual subscriptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,28 +90,30 @@ By default, the currency used is `USD`. If you wish to change it, you may call `
 $provider->setCurrency('EUR');
 ```
 
-## Initiating an order for Checkout
-Use the createOrder method to initiate an order
+## Create Recurring Monthly Subscription
+
 ```php
-$provider->createOrder([
-  "intent"=> "CAPTURE",
-  "purchase_units"=> [
-      0 => [
-          "amount"=> [
-              "currency_code"=> "USD",
-              "value"=> "100.00"
-          ]
-      ]
-  ]
-]);
+$response = $provider->addProduct('Demo Product', 'Demo Product', 'SERVICE', 'SOFTWARE')
+            ->addSubscriptionTrialPricing('DAY', 7)
+            ->addMonthlyPlan('Demo Plan', 'Demo Plan', 100)
+            ->setupSubscription('John Doe', 'john@example.com', '2021-12-10') ;
 ```
 
-The response from this will include an order ID which you will need to retail, and a links collection
-so you can redirect the user to Paypal to complete the order with their payment details
+## Create Recurring Annual Subscription
 
-When the user returns to the notification url you can capture the order payment with
 ```php
-$provider->capturePaymentOrder($order_id); //order id from the createOrder step 
+$response = $provider->addProduct('Demo Product', 'Demo Product', 'SERVICE', 'SOFTWARE')
+            ->addSubscriptionTrialPricing('DAY', 7)
+            ->addAnnualPlan('Demo Plan', 'Demo Plan', 100)
+            ->setupSubscription('John Doe', 'john@example.com', '2021-12-10') ;
+```
+
+## Create Subscription by Existing Product & Billing Plan
+
+```php
+$response = $this->client->addProductById('PROD-XYAB12ABSB7868434')
+    ->addBillingPlanById('P-5ML4271244454362WXNWU5NQ')
+    ->setupSubscription('John Doe', 'john@example.com', $start_date);
 ```
 
 <a name="support"></a>

--- a/src/Traits/PayPalAPI/BillingPlans.php
+++ b/src/Traits/PayPalAPI/BillingPlans.php
@@ -7,7 +7,8 @@ trait BillingPlans
     /**
      * Create a new billing plan.
      *
-     * @param array $data
+     * @param array  $data
+     * @param string $request_id
      *
      * @throws \Throwable
      *
@@ -15,10 +16,11 @@ trait BillingPlans
      *
      * @see https://developer.paypal.com/docs/api/subscriptions/v1/#plans_create
      */
-    public function createPlan(array $data)
+    public function createPlan(array $data, string $request_id)
     {
         $this->apiEndPoint = 'v1/billing/plans';
 
+        $this->options['headers']['PayPal-Request-Id'] = $request_id;
         $this->options['json'] = $data;
 
         $this->verb = 'post';

--- a/src/Traits/PayPalAPI/Subscriptions.php
+++ b/src/Traits/PayPalAPI/Subscriptions.php
@@ -6,6 +6,8 @@ use Carbon\Carbon;
 
 trait Subscriptions
 {
+    use Subscriptions\Helpers;
+
     /**
      * Create a new subscription.
      *

--- a/src/Traits/PayPalAPI/Subscriptions/Helpers.php
+++ b/src/Traits/PayPalAPI/Subscriptions/Helpers.php
@@ -81,9 +81,9 @@ trait Helpers
     /**
      * Create a monthly billing plan.
      *
-     * @param string     $name
-     * @param string     $description
-     * @param float|int  $price
+     * @param string    $name
+     * @param string    $description
+     * @param float|int $price
      *
      * @throws Throwable
      *
@@ -119,7 +119,7 @@ trait Helpers
             'fixed_price' => [
                 'value'         => $price,
                 'currency_code' => $this->getCurrency(),
-            ]
+            ],
         ];
 
         return [
@@ -148,6 +148,10 @@ trait Helpers
      */
     public function addProduct(string $name, string $description, string $type, string $category): \Srmklive\PayPal\Services\PayPal
     {
+        if (isset($this->product)) {
+            return $this;
+        }
+
         $request_id = Str::random();
 
         $this->product = $this->createProduct([

--- a/src/Traits/PayPalAPI/Subscriptions/Helpers.php
+++ b/src/Traits/PayPalAPI/Subscriptions/Helpers.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Srmklive\PayPal\Traits\PayPalAPI\Subscriptions;
+
+use Carbon\Carbon;
+use Illuminate\Support\Str;
+use Throwable;
+
+trait Helpers
+{
+    /**
+     * @var array
+     */
+    protected $trial_pricing = [];
+
+    /**
+     * @var int
+     */
+    protected $payment_failure_threshold = 3;
+
+    /**
+     * @var array
+     */
+    protected $product;
+
+    /**
+     * @var array
+     */
+    protected $billing_plan;
+
+    /**
+     * Setup a subscription.
+     *
+     * @param string $customer_name
+     * @param string $customer_email
+     * @param string $start_date
+     *
+     * @throws Throwable
+     *
+     * @return array|\Psr\Http\Message\StreamInterface|string
+     */
+    public function setupSubscription(string $customer_name, string $customer_email, string $start_date = '')
+    {
+        $start_date = isset($start_date) ? Carbon::parse($start_date)->toIso8601String() : Carbon::now()->toIso8601String();
+
+        $subscription = $this->createSubscription([
+            'plan_id'    => $this->billing_plan['id'],
+            'start_time' => $start_date,
+            'quantity'   => 1,
+            'subscriber' => [
+                'name'          => [
+                    'given_name' => $customer_name,
+                ],
+                'email_address' => $customer_email,
+            ],
+        ]);
+
+        unset($this->product);
+        unset($this->billing_plan);
+        unset($this->trial_pricing);
+
+        return $subscription;
+    }
+
+    /**
+     * Add a subscription trial pricing tier.
+     *
+     * @param string    $interval_type
+     * @param string    $interval_count
+     * @param float|int $price
+     *
+     * @return \Srmklive\PayPal\Services\PayPal
+     */
+    public function addSubscriptionTrialPricing(string $interval_type, string $interval_count, float $price = 0): \Srmklive\PayPal\Services\PayPal
+    {
+        $this->trial_pricing = $this->addPlanBillingCycle($interval_type, $interval_count, $price, true);
+
+        return $this;
+    }
+
+    /**
+     * Create a monthly billing plan.
+     *
+     * @param string     $name
+     * @param string     $description
+     * @param float|int  $price
+     *
+     * @throws Throwable
+     *
+     * @return \Srmklive\PayPal\Services\PayPal
+     */
+    public function addMonthlyPlan(string $name, string $description, float $price): \Srmklive\PayPal\Services\PayPal
+    {
+        if (isset($this->billing_plan)) {
+            return $this;
+        }
+
+        $plan_pricing = $this->addPlanBillingCycle('MONTH', 1, $price);
+        $billing_cycles = collect([$this->trial_pricing, $plan_pricing])->filter()->toArray();
+
+        $this->addBillingPlan($name, $description, $billing_cycles);
+
+        return $this;
+    }
+
+    /**
+     * Add Plan's Billing cycle.
+     *
+     * @param string $interval_unit
+     * @param int    $interval_count
+     * @param float  $price
+     * @param bool   $trial
+     *
+     * @return array
+     */
+    protected function addPlanBillingCycle(string $interval_unit, int $interval_count, float $price, bool $trial = false): array
+    {
+        $pricing_scheme = [
+            'fixed_price' => [
+                'value'         => $price,
+                'currency_code' => $this->getCurrency(),
+            ]
+        ];
+
+        return [
+            'frequency' => [
+                'interval_unit'  => $interval_unit,
+                'interval_count' => $interval_count,
+            ],
+            'tenure_type'    => ($trial === true) ? 'TRIAL' : 'REGULAR',
+            'sequence'       => ($trial === true) ? 1 : 2,
+            'total_cycles'   => ($trial === true) ? 1 : 0,
+            'pricing_scheme' => $pricing_scheme,
+        ];
+    }
+
+    /**
+     * Create a product for a subscription's billing plan.
+     *
+     * @param string $name
+     * @param string $description
+     * @param string $type
+     * @param string $category
+     *
+     * @throws Throwable
+     *
+     * @return \Srmklive\PayPal\Services\PayPal
+     */
+    public function addProduct(string $name, string $description, string $type, string $category): \Srmklive\PayPal\Services\PayPal
+    {
+        $request_id = Str::random();
+
+        $this->product = $this->createProduct([
+            'name'          => $name,
+            'description'   => $description,
+            'type'          => $type,
+            'category'      => $category,
+        ], $request_id);
+
+        return $this;
+    }
+
+    /**
+     * Add subscription's billing plan's product by ID.
+     *
+     * @param string $product_id
+     *
+     * @return \Srmklive\PayPal\Services\PayPal
+     */
+    public function addProductById(string $product_id): \Srmklive\PayPal\Services\PayPal
+    {
+        $this->product = [
+            'id' => $product_id,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Add subscription's billing plan by ID.
+     *
+     * @param string $plan_id
+     *
+     * @return \Srmklive\PayPal\Services\PayPal
+     */
+    public function addBillingPlanById(string $plan_id): \Srmklive\PayPal\Services\PayPal
+    {
+        $this->billing_plan = [
+            'id' => $plan_id,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Create a product for a subscription's billing plan.
+     *
+     * @param string $name
+     * @param string $description
+     * @param array  $billing_cycles
+     *
+     * @throws Throwable
+     *
+     * @return void
+     */
+    protected function addBillingPlan(string $name, string $description, array $billing_cycles): void
+    {
+        $request_id = Str::random();
+
+        $plan_params = [
+            'product_id'          => $this->product['id'],
+            'name'                => $name,
+            'description'         => $description,
+            'status'              => 'ACTIVE',
+            'billing_cycles'      => $billing_cycles,
+            'payment_preferences' => [
+                'auto_bill_outstanding'     => true,
+                'setup_fee_failure_action'  => 'CONTINUE',
+                'payment_failure_threshold' => $this->payment_failure_threshold,
+            ],
+        ];
+
+        $this->billing_plan = $this->createPlan($plan_params, $request_id);
+    }
+}

--- a/src/Traits/PayPalAPI/Subscriptions/Helpers.php
+++ b/src/Traits/PayPalAPI/Subscriptions/Helpers.php
@@ -79,7 +79,7 @@ trait Helpers
     }
 
     /**
-     * Create a monthly billing plan.
+     * Create a recurring monthly billing plan.
      *
      * @param string    $name
      * @param string    $description
@@ -96,6 +96,31 @@ trait Helpers
         }
 
         $plan_pricing = $this->addPlanBillingCycle('MONTH', 1, $price);
+        $billing_cycles = collect([$this->trial_pricing, $plan_pricing])->filter()->toArray();
+
+        $this->addBillingPlan($name, $description, $billing_cycles);
+
+        return $this;
+    }
+
+    /**
+     * Create a recurring annual billing plan.
+     *
+     * @param string    $name
+     * @param string    $description
+     * @param float|int $price
+     *
+     * @throws Throwable
+     *
+     * @return \Srmklive\PayPal\Services\PayPal
+     */
+    public function addAnnualPlan(string $name, string $description, float $price): \Srmklive\PayPal\Services\PayPal
+    {
+        if (isset($this->billing_plan)) {
+            return $this;
+        }
+
+        $plan_pricing = $this->addPlanBillingCycle('YEAR', 1, $price);
         $billing_cycles = collect([$this->trial_pricing, $plan_pricing])->filter()->toArray();
 
         $this->addBillingPlan($name, $description, $billing_cycles);

--- a/tests/Feature/AdapterCreateSubscriptionHelpersTest.php
+++ b/tests/Feature/AdapterCreateSubscriptionHelpersTest.php
@@ -36,7 +36,7 @@ class AdapterCreateSubscriptionHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_create_a_monthly_subscription_by_creating_new_product_and_billing_plan()
+    public function it_can_create_a_monthly_subscription()
     {
         $this->client->setAccessToken([
             'access_token'  => self::$access_token,
@@ -61,6 +61,85 @@ class AdapterCreateSubscriptionHelpersTest extends TestCase
 
         $this->client = $this->client->addSubscriptionTrialPricing('DAY', 7)
             ->addMonthlyPlan('Demo Plan', 'Demo Plan', 100);
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreateSubscriptionResponse()
+            )
+        );
+
+        $response = $this->client->setupSubscription('John Doe', 'john@example.com', $start_date);
+
+        $this->assertNotEmpty($response);
+        $this->assertArrayHasKey('id', $response);
+        $this->assertArrayHasKey('plan_id', $response);
+    }
+
+    /** @test */
+    public function it_can_create_an_annual_subscription()
+    {
+        $this->client->setAccessToken([
+            'access_token'  => self::$access_token,
+            'token_type'    => 'Bearer',
+        ]);
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreateCatalogProductsResponse()
+            )
+        );
+
+        $start_date = Carbon::now()->addDay()->toDateString();
+
+        $this->client = $this->client->addProduct('Demo Product', 'Demo Product', 'SERVICE', 'SOFTWARE');
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreatePlansResponse()
+            )
+        );
+
+        $this->client = $this->client->addSubscriptionTrialPricing('DAY', 7)
+            ->addAnnualPlan('Demo Plan', 'Demo Plan', 100);
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreateSubscriptionResponse()
+            )
+        );
+
+        $response = $this->client->setupSubscription('John Doe', 'john@example.com', $start_date);
+
+        $this->assertNotEmpty($response);
+        $this->assertArrayHasKey('id', $response);
+        $this->assertArrayHasKey('plan_id', $response);
+    }
+
+    /** @test */
+    public function it_can_create_a_subscription_without_trial()
+    {
+        $this->client->setAccessToken([
+            'access_token'  => self::$access_token,
+            'token_type'    => 'Bearer',
+        ]);
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreateCatalogProductsResponse()
+            )
+        );
+
+        $start_date = Carbon::now()->addDay()->toDateString();
+
+        $this->client = $this->client->addProduct('Demo Product', 'Demo Product', 'SERVICE', 'SOFTWARE');
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreatePlansResponse()
+            )
+        );
+
+        $this->client = $this->client->addMonthlyPlan('Demo Plan', 'Demo Plan', 100);
 
         $this->client->setClient(
             $this->mock_http_client(

--- a/tests/Feature/AdapterCreateSubscriptionHelpersTest.php
+++ b/tests/Feature/AdapterCreateSubscriptionHelpersTest.php
@@ -99,4 +99,33 @@ class AdapterCreateSubscriptionHelpersTest extends TestCase
         $this->assertArrayHasKey('id', $response);
         $this->assertArrayHasKey('plan_id', $response);
     }
+
+    /** @test */
+    public function it_skips_product_and_billing_plan_creation_if_already_set_when_creating_a_subscription()
+    {
+        $this->client->setAccessToken([
+            'access_token'  => self::$access_token,
+            'token_type'    => 'Bearer',
+        ]);
+
+        $start_date = Carbon::now()->addDay()->toDateString();
+
+        $this->client = $this->client->addProductById('PROD-XYAB12ABSB7868434')
+            ->addBillingPlanById('P-5ML4271244454362WXNWU5NQ')
+            ->addProduct('Demo Product', 'Demo Product', 'SERVICE', 'SOFTWARE')
+            ->addSubscriptionTrialPricing('DAY', 7)
+            ->addMonthlyPlan('Demo Plan', 'Demo Plan', 100);
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreateSubscriptionResponse()
+            )
+        );
+
+        $response = $this->client->setupSubscription('John Doe', 'john@example.com', $start_date);
+
+        $this->assertNotEmpty($response);
+        $this->assertArrayHasKey('id', $response);
+        $this->assertArrayHasKey('plan_id', $response);
+    }
 }

--- a/tests/Feature/AdapterCreateSubscriptionHelpersTest.php
+++ b/tests/Feature/AdapterCreateSubscriptionHelpersTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Srmklive\PayPal\Tests\Feature;
+
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+use Srmklive\PayPal\Services\PayPal as PayPalClient;
+use Srmklive\PayPal\Tests\MockClientClasses;
+use Srmklive\PayPal\Tests\MockResponsePayloads;
+
+class AdapterCreateSubscriptionHelpersTest extends TestCase
+{
+    use MockClientClasses;
+    use MockResponsePayloads;
+
+    /** @var string */
+    protected static $access_token = '';
+
+    /** @var \Srmklive\PayPal\Services\PayPal */
+    protected $client;
+
+    protected function setUp(): void
+    {
+        $this->client = new PayPalClient($this->getApiCredentials());
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockAccessTokenResponse()
+            )
+        );
+        $response = $this->client->getAccessToken();
+
+        self::$access_token = $response['access_token'];
+
+        parent::setUp();
+    }
+
+    /** @test */
+    public function it_can_create_a_monthly_subscription_by_creating_new_product_and_billing_plan()
+    {
+        $this->client->setAccessToken([
+            'access_token'  => self::$access_token,
+            'token_type'    => 'Bearer',
+        ]);
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreateCatalogProductsResponse()
+            )
+        );
+
+        $start_date = Carbon::now()->addDay()->toDateString();
+
+        $this->client = $this->client->addProduct('Demo Product', 'Demo Product', 'SERVICE', 'SOFTWARE');
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreatePlansResponse()
+            )
+        );
+
+        $this->client = $this->client->addSubscriptionTrialPricing('DAY', 7)
+            ->addMonthlyPlan('Demo Plan', 'Demo Plan', 100);
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreateSubscriptionResponse()
+            )
+        );
+
+        $response = $this->client->setupSubscription('John Doe', 'john@example.com', $start_date);
+
+        $this->assertNotEmpty($response);
+        $this->assertArrayHasKey('id', $response);
+        $this->assertArrayHasKey('plan_id', $response);
+    }
+
+    /** @test */
+    public function it_can_create_a_monthly_subscription_by_existing_product_and_billing_plan()
+    {
+        $this->client->setAccessToken([
+            'access_token'  => self::$access_token,
+            'token_type'    => 'Bearer',
+        ]);
+
+        $start_date = Carbon::now()->addDay()->toDateString();
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreateSubscriptionResponse()
+            )
+        );
+
+        $response = $this->client->addProductById('PROD-XYAB12ABSB7868434')
+            ->addBillingPlanById('P-5ML4271244454362WXNWU5NQ')
+            ->setupSubscription('John Doe', 'john@example.com', $start_date);
+
+        $this->assertNotEmpty($response);
+        $this->assertArrayHasKey('id', $response);
+        $this->assertArrayHasKey('plan_id', $response);
+    }
+}

--- a/tests/Feature/AdapterCreateSubscriptionHelpersTest.php
+++ b/tests/Feature/AdapterCreateSubscriptionHelpersTest.php
@@ -180,7 +180,7 @@ class AdapterCreateSubscriptionHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_skips_product_and_billing_plan_creation_if_already_set_when_creating_a_subscription()
+    public function it_skips_product_and_billing_plan_creation_if_already_set_when_creating_a_monthly_subscription()
     {
         $this->client->setAccessToken([
             'access_token'  => self::$access_token,
@@ -194,6 +194,35 @@ class AdapterCreateSubscriptionHelpersTest extends TestCase
             ->addProduct('Demo Product', 'Demo Product', 'SERVICE', 'SOFTWARE')
             ->addSubscriptionTrialPricing('DAY', 7)
             ->addMonthlyPlan('Demo Plan', 'Demo Plan', 100);
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreateSubscriptionResponse()
+            )
+        );
+
+        $response = $this->client->setupSubscription('John Doe', 'john@example.com', $start_date);
+
+        $this->assertNotEmpty($response);
+        $this->assertArrayHasKey('id', $response);
+        $this->assertArrayHasKey('plan_id', $response);
+    }
+
+    /** @test */
+    public function it_skips_product_and_billing_plan_creation_if_already_set_when_creating_an_annual_subscription()
+    {
+        $this->client->setAccessToken([
+            'access_token'  => self::$access_token,
+            'token_type'    => 'Bearer',
+        ]);
+
+        $start_date = Carbon::now()->addDay()->toDateString();
+
+        $this->client = $this->client->addProductById('PROD-XYAB12ABSB7868434')
+            ->addBillingPlanById('P-5ML4271244454362WXNWU5NQ')
+            ->addProduct('Demo Product', 'Demo Product', 'SERVICE', 'SOFTWARE')
+            ->addSubscriptionTrialPricing('DAY', 7)
+            ->addAnnualPlan('Demo Plan', 'Demo Plan', 100);
 
         $this->client->setClient(
             $this->mock_http_client(

--- a/tests/Feature/AdapterFeatureTest.php
+++ b/tests/Feature/AdapterFeatureTest.php
@@ -73,7 +73,7 @@ class AdapterFeatureTest extends TestCase
 
         $expectedParams = $this->createPlanParams();
 
-        $response = $this->client->createPlan($expectedParams);
+        $response = $this->client->createPlan($expectedParams, 'some-request-id');
 
         $this->assertNotEmpty($response);
         $this->assertArrayHasKey('id', $response);

--- a/tests/Unit/Adapter/BillingPlansTest.php
+++ b/tests/Unit/Adapter/BillingPlansTest.php
@@ -27,7 +27,7 @@ class BillingPlansTest extends TestCase
         $mockClient->setApiCredentials($this->getMockCredentials());
         $mockClient->getAccessToken();
 
-        $this->assertEquals($expectedResponse, $mockClient->{$expectedMethod}($expectedParams));
+        $this->assertEquals($expectedResponse, $mockClient->{$expectedMethod}($expectedParams, 'some-request-id'));
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds helper methods to the package to allow developers to create:

- Recurring monthly subscription.
- Recurring annual subscription.

Following is the code snippet, through which a new subscription is created by first adding a new product & billing plan.
```
use Srmklive\PayPal\Services\PayPal as PayPalClient;

$client = new PayPalClient();

// Create recurring monthly subscription by creating a new product & billing plan.
$response= $this->client->addProduct('Demo Product', 'Demo Product', 'SERVICE', 'SOFTWARE')
            ->addSubscriptionTrialPricing('DAY', 7)
            ->addMonthlyPlan('Demo Plan', 'Demo Plan', 100)
            ->setupSubscription('John Doe', 'john@example.com', '2021-12-10') ;

// Create recurring annual subscription by creating a new product & billing plan.
$response= $this->client->addProduct('Demo Product', 'Demo Product', 'SERVICE', 'SOFTWARE')
            ->addSubscriptionTrialPricing('DAY', 7)
            ->addAnnualPlan('Demo Plan', 'Demo Plan', 100)
            ->setupSubscription('John Doe', 'john@example.com', '2021-12-10') ;
```

You may also specify a current product & billing plan id to create a new subscription:

```
$response = $client->addProductById('PROD-XYAB12ABSB7868434')
    ->addBillingPlanById('P-5ML4271244454362WXNWU5NQ')
    ->setupSubscription('John Doe', 'john@example.com', $start_date);
```
