### PR TITLE
Caching `access_token`/`app_id` Issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
   },
   "require": {
     "php": ">=7.2|^8.0",
+    "ext-curl": "*",
     "guzzlehttp/guzzle": "~7.0",
     "illuminate/support": "~6.0|~7.0|~8.0|~9.0",
     "nesbot/carbon": "~2.0"

--- a/src/Traits/PayPalAPI.php
+++ b/src/Traits/PayPalAPI.php
@@ -53,8 +53,6 @@ trait PayPalAPI
 
         if (isset($response['access_token'])) {
             $this->setAccessToken($response);
-
-            $this->setPayPalAppId($response);
         }
 
         return $response;
@@ -70,6 +68,8 @@ trait PayPalAPI
     public function setAccessToken(array $response)
     {
         $this->access_token = $response['access_token'];
+
+        $this->setPayPalAppId($response);
 
         $this->options['headers']['Authorization'] = "{$response['token_type']} {$this->access_token}";
     }


### PR DESCRIPTION
## Issue
When an `access_token` is requested every time (without caching) and the `PAYPAL_LIVE_APP_ID` environment variable is never set, there is no issue.

But requesting too many `access_token` values can result in getting a bad request from PayPal. So one needs to add caching:
```php
<?php

use App\Http\Controllers\Controller;
use Srmklive\PayPal\Services\PayPal as PayPalClient;

class PayPalPaymentController extends Controller
{
    function setupClient(): PayPalClient
    {
        $client = new PayPalClient;
        $cacheKey = 'paypal_access_token';
        $client->setApiCredentials(config('paypal'));
        $response = cache()->get($cacheKey);
        if (!is_array($response)) {
            $response = $client->getAccessToken();
            cache()->set($cacheKey, $response, $response['expires_in']);
        }
        $client->setAccessToken($response);
        return $client;
    }
}
```
In the case above `getAccessToken` will set the `app_id` initially but then afterward the value will not be set when pulling from `cache()->get()`.

## Solution
### Move `setPayPalAppId` call
Move the call to `setPayPalAppId` into `setAccessToken`.

Also you're referencing `CURL_SSLVERSION_TLSv1_2` which requires `ext-curl` so I added it to the `composer.json`.

### Do Nothing
The other solution is just to set `PAYPAL_LIVE_APP_ID`.

### Make setPayPalAppId `public` method
Or the final option is to change `setPayPalAppId` to be a `public` method. Not sure why it needs to be `private`.

Implementation can then be:
```php
<?php

use App\Http\Controllers\Controller;
use Srmklive\PayPal\Services\PayPal as PayPalClient;

class PayPalPaymentController extends Controller
{
    function setupClient(): PayPalClient
    {
        $client = new PayPalClient;
        $cacheKey = 'paypal_access_token';
        $client->setApiCredentials(config('paypal'));
        $response = cache()->get($cacheKey);
        if (!is_array($response)) {
            $response = $client->getAccessToken();
            cache()->set($cacheKey, $response, $response['expires_in']);
        }
        $client->setAccessToken($response);
        $client->setPayPalAppId($response);
        return $client;
    }
}
```
