### PR TITLE
Unifying error return type

### DIFF
--- a/src/Traits/PayPalVerifyIPN.php
+++ b/src/Traits/PayPalVerifyIPN.php
@@ -20,7 +20,7 @@ trait PayPalVerifyIPN
      *
      * @return array|\Psr\Http\Message\StreamInterface|string
      */
-    public function verifyIPN(\Illuminate\Http\Request $request)
+    public function verifyIPN(\Illuminate\Http\Request $requestw)
     {
         $headers = array_change_key_case($request->headers->all(), CASE_UPPER);
 
@@ -33,10 +33,7 @@ trait PayPalVerifyIPN
         ) {
             \Log::error('Invalid headers or webhook id supplied for paypal webhook');
 
-            return response()->json([
-                'status'  => 'error',
-                'message' => 'Invalid headers or web hook id provided',
-            ]);
+            return ['error' => 'Invalid headers or webhook id provided'];
         }
 
         $params = $request->all();

--- a/src/Traits/PayPalVerifyIPN.php
+++ b/src/Traits/PayPalVerifyIPN.php
@@ -20,7 +20,7 @@ trait PayPalVerifyIPN
      *
      * @return array|\Psr\Http\Message\StreamInterface|string
      */
-    public function verifyIPN(\Illuminate\Http\Request $requestw)
+    public function verifyIPN(\Illuminate\Http\Request $request)
     {
         $headers = array_change_key_case($request->headers->all(), CASE_UPPER);
 


### PR DESCRIPTION
Resolves #514

verifyIPN now returns an array with the `error` key when invalid headers or webhook id is provided.
This is the same behavior as when `doPayPalRequest(true)` catches an error (updated in commit d9ad3ef9b27299788b4896aab8beeea40b24deca)