### PR TITLE
Helper to add application context to subscription.

### DIFF
--- a/src/Traits/PayPalAPI/Subscriptions/Helpers.php
+++ b/src/Traits/PayPalAPI/Subscriptions/Helpers.php
@@ -54,6 +54,11 @@ trait Helpers
     protected $cancel_url;
 
     /**
+     * @var array
+     */
+    protected $application_context;
+
+    /**
      * Setup a subscription.
      *
      * @param string $customer_name
@@ -90,11 +95,13 @@ trait Helpers
             $body['subscriber']['shipping_address'] = $this->shipping_address;
         }
 
+        if (!empty($this->application_context)) {
+            $body['application_context'] = $this->application_context;
+        }
+
         if ($this->return_url && $this->cancel_url) {
-            $body['application_context'] = [
-                'return_url' => $this->return_url,
-                'cancel_url' => $this->cancel_url,
-            ];
+            $body['application_context']['return_url'] = $this->return_url;
+            $body['application_context']['cancel_url'] = $this->cancel_url;
         }
 
         $subscription = $this->createSubscription($body);
@@ -104,6 +111,7 @@ trait Helpers
         unset($this->trial_pricing);
         unset($this->return_url);
         unset($this->cancel_url);
+        unset($this->application_context);
 
         return $subscription;
     }
@@ -385,6 +393,19 @@ trait Helpers
         ];
 
         $this->billing_plan = $this->createPlan($plan_params, $request_id);
+    }
+
+    /**
+     * Set application context.
+     *
+     * @param array $data
+     * @return \Srmklive\PayPal\Services\PayPal
+     */
+    public function setApplicationContext(array $data): \Srmklive\PayPal\Services\PayPal
+    {
+        $this->application_context = $data;
+
+        return $this;
     }
 
     /**

--- a/src/Traits/PayPalAPI/Subscriptions/Helpers.php
+++ b/src/Traits/PayPalAPI/Subscriptions/Helpers.php
@@ -399,7 +399,7 @@ trait Helpers
      * Set application context.
      *
      * @param array $data
-     * 
+     *
      * @return \Srmklive\PayPal\Services\PayPal
      */
     public function setApplicationContext(array $data): \Srmklive\PayPal\Services\PayPal

--- a/src/Traits/PayPalAPI/Subscriptions/Helpers.php
+++ b/src/Traits/PayPalAPI/Subscriptions/Helpers.php
@@ -399,6 +399,7 @@ trait Helpers
      * Set application context.
      *
      * @param array $data
+     * 
      * @return \Srmklive\PayPal\Services\PayPal
      */
     public function setApplicationContext(array $data): \Srmklive\PayPal\Services\PayPal


### PR DESCRIPTION
I've been trying to add custom brand name and turn shipping off in PayPal payment screen for subscriptions and found myself unable to do this since package only allows changing `return_url` and `cancel_url` parameters for `application_context` object sent to PayPal. 

I've added very simple but helpful setter method which can set `application_context` but still keep old feature of adding `return_url` and `cancel_url`.

Note: I've never done a pull request on an public package so if I missed something or did something wrong my apologizes. 

Edit: I was also considering making an enum for `shipping_preference` field inside `application_context` since that field is an enum in PayPal documentation as well. It would help people not mess up its value I hoped. What you think about this? I could make another PR or just include it in this one if you agree.