### PR TITLE
Fix JSON decoding error in PayPalClient

### DIFF
--- a/src/Traits/PayPalHttpClient.php
+++ b/src/Traits/PayPalHttpClient.php
@@ -211,7 +211,7 @@ trait PayPalHttpClient
 
             return ($decode === false) ? $response->getContents() : Utils::jsonDecode($response, true);
         } catch (RuntimeException $t) {
-            return ($decode === false) ? $t->getMessage() : Utils::jsonDecode('{"error":'.$t->getMessage().'}', true);
+            return ($decode === false) ? $t->getMessage() : Utils::jsonDecode('{"error":"'.$t->getMessage().'"}', true);
         }
     }
 }


### PR DESCRIPTION
Replace concatenation with string interpolation in the doPayPalRequest method of PayPalClient to properly encode error messages as JSON. Previously, an error occurred when attempting to decode error messages with JSON keys that were not surrounded by quotes.