### PR TITLE
Add reference transactions endpoints.

### DIFF
--- a/src/Traits/PayPalAPI.php
+++ b/src/Traits/PayPalAPI.php
@@ -5,6 +5,7 @@ namespace Srmklive\PayPal\Traits;
 trait PayPalAPI
 {
     use PayPalAPI\Trackers;
+    use PayPalAPI\BillingAgreements;
     use PayPalAPI\CatalogProducts;
     use PayPalAPI\Disputes;
     use PayPalAPI\DisputesActions;

--- a/src/Traits/PayPalAPI/BillingAgreements.php
+++ b/src/Traits/PayPalAPI/BillingAgreements.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Srmklive\PayPal\Traits\PayPalAPI;
+
+trait BillingAgreements {
+
+    /**
+     * Creates a billing agreement token.
+     *
+     * @param array $data
+     *
+     * @throws \Throwable
+     *
+     * @return array|\Psr\Http\Message\StreamInterface|string
+     *
+     * @see https://developer.paypal.com/limited-release/reference-transactions/#link-createbillingagreementtoken
+     */
+    public function createBillingAgreementToken (array $data) {
+        $this->apiEndPoint = 'v1/billing-agreements/agreement-tokens';
+
+        $this->options['json'] = (object) $data;
+
+        $this->verb = 'post';
+
+        return $this->doPayPalRequest();
+    }
+
+    /**
+     * After payer approval, use a billing agreement token to create the agreement.
+     *
+     * @param string $billingAgreementToken
+     *
+     * @throws \Throwable
+     *
+     * @return array|\Psr\Http\Message\StreamInterface|string
+     *
+     * @see https://developer.paypal.com/limited-release/reference-transactions/#link-createbillingagreement
+     */
+    public function createBillingAgreement (string $billingAgreementToken) {
+        $this->apiEndPoint = "v1/billing-agreements/{$billingAgreementToken}/agreements";
+
+        $this->verb = 'post';
+
+        return $this->doPayPalRequest();
+    }
+}


### PR DESCRIPTION
Add the PayPal Reference Transactions endpoints to create and manage billing agreement tokens and billing agreements.
For more information: [https://developer.paypal.com/limited-release/reference-transactions](url)
