### PR TITLE
Support `nesbot/carbon:~3.0` in `v1.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "guzzlehttp/guzzle": "~6.0|~7.0",
     "illuminate/support": "~5.1|~5.2|~5.3|~5.4|~5.5|~5.6|~5.7|~5.8|~6.0|~7.0|~8.0|~9.0|~10.0|~11.0",
-    "nesbot/carbon": "~1.0|~2.0"
+    "nesbot/carbon": "~1.0|~2.0|~3.0"
   },
   "config": {
     "sort-packages": true


### PR DESCRIPTION
This PR updates `composer.json` in the `v1.0` branch so it accepts `nesbot/carbon:~3.0`.

There is no tests in this branch but from what I've seen from the current Carbon usage, this update shouldn't be a problem.

For reference, this is the upgrade guide https://carbon.nesbot.com/docs/#api-carbon-3

Have a nice day