### PR TITLE
Add support for the Reference Transactions API

### DIFF
--- a/src/Traits/PayPalAPI.php
+++ b/src/Traits/PayPalAPI.php
@@ -21,6 +21,7 @@ trait PayPalAPI
     use PayPalAPI\PaymentRefunds;
     use PayPalAPI\Payouts;
     use PayPalAPI\ReferencedPayouts;
+    use PayPalAPI\BillingAgreements;
     use PayPalAPI\BillingPlans;
     use PayPalAPI\Subscriptions;
     use PayPalAPI\Reporting;

--- a/src/Traits/PayPalAPI/BillingAgreements.php
+++ b/src/Traits/PayPalAPI/BillingAgreements.php
@@ -25,7 +25,7 @@ trait BillingAgreements
      */
     public function createBillingAgreementToken(array $data)
     {
-        $this->apiEndPoint = '/v1/billing-agreements/agreement-tokens';
+        $this->apiEndPoint = 'v1/billing-agreements/agreement-tokens';
 
         $this->options['json'] = $data;
 
@@ -47,7 +47,7 @@ trait BillingAgreements
      */
     public function getBillingAgreementTokenDetails(string $token_id)
     {
-        $this->apiEndPoint = "/v1/billing-agreements/agreement-tokens/{$token_id}";
+        $this->apiEndPoint = "v1/billing-agreements/agreement-tokens/{$token_id}";
 
         $this->verb = 'get';
 
@@ -67,7 +67,7 @@ trait BillingAgreements
      */
     public function createBillingAgreement(string $token_id)
     {
-        $this->apiEndPoint = '/v1/billing-agreements/agreements';
+        $this->apiEndPoint = 'v1/billing-agreements/agreements';
 
         $this->options['json'] = [
             'token_id' => $token_id,
@@ -92,7 +92,7 @@ trait BillingAgreements
      */
     public function updateBillingAgreement(string $agreement_id, array $data)
     {
-        $this->apiEndPoint = "/v1/billing-agreements/agreements/{$agreement_id}";
+        $this->apiEndPoint = "v1/billing-agreements/agreements/{$agreement_id}";
 
         $this->options['json'] = $data;
 
@@ -114,7 +114,7 @@ trait BillingAgreements
      */
     public function showBillingAgreementDetails(string $agreement_id)
     {
-        $this->apiEndPoint = "/v1/billing-agreements/agreements/{$agreement_id}";
+        $this->apiEndPoint = "v1/billing-agreements/agreements/{$agreement_id}";
 
         $this->verb = 'get';
 
@@ -134,7 +134,7 @@ trait BillingAgreements
      */
     public function cancelBillingAgreement(string $agreement_id)
     {
-        $this->apiEndPoint = "/v1/billing-agreements/agreements/{$agreement_id}/cancel";
+        $this->apiEndPoint = "v1/billing-agreements/agreements/{$agreement_id}/cancel";
 
         $this->verb = 'post';
 

--- a/src/Traits/PayPalAPI/BillingAgreements.php
+++ b/src/Traits/PayPalAPI/BillingAgreements.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Srmklive\PayPal\Traits\PayPalAPI;
+
+/**
+ * This trait provides methods for the Reference Transactions API,
+ * which is available on a limited-use basis.
+ *
+ * See: https://developer.paypal.com/limited-release/reference-transactions/
+ * and https://developer.paypal.com/api/limited-release/reference-transactions/v1/
+ * for more details.
+ */
+trait BillingAgreements
+{
+    /**
+     * Create a new billing agreement.
+     *
+     * @param array $data
+     *
+     * @return array|\Psr\Http\Message\StreamInterface|string
+     *
+     * @throws \Throwable
+     *
+     * @see https://developer.paypal.com/api/limited-release/reference-transactions/v1/#agreement-tokens_post
+     */
+    public function createBillingAgreementToken(array $data)
+    {
+        $this->apiEndPoint = '/v1/billing-agreements/agreement-tokens';
+
+        $this->options['json'] = $data;
+
+        $this->verb = 'post';
+
+        return $this->doPayPalRequest();
+    }
+
+    /**
+     * Get details of a billing agreement token.
+     *
+     * @param string $token_id
+     *
+     * @throws \Throwable
+     *
+     * @return array|string|\Psr\Http\Message\StreamInterface
+     *
+     * @see https://developer.paypal.com/api/limited-release/reference-transactions/v1/#agreement-tokens_get
+     */
+    public function getBillingAgreementTokenDetails(string $token_id)
+    {
+        $this->apiEndPoint = "/v1/billing-agreements/agreement-tokens/{$token_id}";
+
+        $this->verb = 'get';
+
+        return $this->doPayPalRequest();
+    }
+
+    /**
+     * Create a billing agreement.
+     *
+     * @param string $token_id
+     *
+     * @throws \Throwable
+     *
+     * @return array|string|\Psr\Http\Message\StreamInterface
+     *
+     * @see https://developer.paypal.com/api/limited-release/reference-transactions/v1/#agreements_create
+     */
+    public function createBillingAgreement(string $token_id) {
+        $this->apiEndPoint = '/v1/billing-agreements/agreements';
+
+        $this->options['json'] = [
+            'token_id' => $token_id,
+        ];
+
+        $this->verb = 'post';
+
+        return $this->doPayPalRequest();
+    }
+
+    /**
+     * Update an existing billing agreement.
+     *
+     * @param string $agreement_id
+     *
+     * @param array $data
+     *
+     * @throws \Throwable
+     *
+     * @return array|string|\Psr\Http\Message\StreamInterface
+     *
+     * @see https://developer.paypal.com/api/limited-release/reference-transactions/v1/#agreements_patch
+     */
+    public function updateBillingAgreement(string $agreement_id, array $data)
+    {
+        $this->apiEndPoint = "/v1/billing-agreements/agreements/{$agreement_id}";
+
+        $this->options['json'] = $data;
+
+        $this->verb = 'patch';
+
+        return $this->doPayPalRequest(false);
+    }
+
+    /**
+     * Show details for an existing billing agreement.
+     *
+     * @param string $agreement_id
+     *
+     * @throws \Throwable
+     *
+     * @return array|string|\Psr\Http\Message\StreamInterface
+     *
+     * @see https://developer.paypal.com/api/limited-release/reference-transactions/v1/#agreements_get
+     */
+    public function showBillingAgreementDetails(string $agreement_id)
+    {
+        $this->apiEndPoint = "/v1/billing-agreements/agreements/{$agreement_id}";
+
+        $this->verb = 'get';
+
+        return $this->doPayPalRequest();
+    }
+
+    /**
+     * Cancel an existing billing agreement.
+     *
+     * @param string $agreement_id
+     *
+     * @throws \Throwable
+     *
+     * @return array|string|\Psr\Http\Message\StreamInterface
+     *
+     * @see https://developer.paypal.com/api/limited-release/reference-transactions/v1/#agreements_cancel
+     */
+    public function cancelBillingAgreement(string $agreement_id)
+    {
+        $this->apiEndPoint = "/v1/billing-agreements/agreements/{$agreement_id}/cancel";
+
+        $this->verb = 'post';
+
+        return $this->doPayPalRequest(false);
+    }
+}

--- a/src/Traits/PayPalAPI/BillingAgreements.php
+++ b/src/Traits/PayPalAPI/BillingAgreements.php
@@ -17,9 +17,9 @@ trait BillingAgreements
      *
      * @param array $data
      *
-     * @return array|\Psr\Http\Message\StreamInterface|string
-     *
      * @throws \Throwable
+     *
+     * @return array|\Psr\Http\Message\StreamInterface|string
      *
      * @see https://developer.paypal.com/api/limited-release/reference-transactions/v1/#agreement-tokens_post
      */
@@ -65,7 +65,8 @@ trait BillingAgreements
      *
      * @see https://developer.paypal.com/api/limited-release/reference-transactions/v1/#agreements_create
      */
-    public function createBillingAgreement(string $token_id) {
+    public function createBillingAgreement(string $token_id)
+    {
         $this->apiEndPoint = '/v1/billing-agreements/agreements';
 
         $this->options['json'] = [
@@ -81,8 +82,7 @@ trait BillingAgreements
      * Update an existing billing agreement.
      *
      * @param string $agreement_id
-     *
-     * @param array $data
+     * @param array  $data
      *
      * @throws \Throwable
      *

--- a/tests/Feature/AdapterFeatureTest.php
+++ b/tests/Feature/AdapterFeatureTest.php
@@ -62,6 +62,142 @@ class AdapterFeatureTest extends TestCase
     }
 
     #[Test]
+    public function it_can_create_a_billing_agreement_token(): void
+    {
+        $this->client->setAccessToken([
+            'access_token'  => self::$access_token,
+            'token_type'    => 'Bearer',
+        ]);
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreateBillingAgreementTokenResponse()
+            )
+        );
+
+        $expectedParams = $this->createBillingAgreementTokenParams();
+
+        try {
+            $response = $this->client->setRequestHeader('PayPal-Request-Id', 'some-request-id')->createBillingAgreementToken($expectedParams);
+        } catch (\Throwable $e) {
+        }
+
+        $this->assertNotEmpty($response);
+        $this->assertArrayHasKey('token_id', $response);
+    }
+
+    #[Test]
+    public function it_can_show_billing_agreement_token_details(): void
+    {
+        $this->client->setAccessToken([
+            'access_token'  => self::$access_token,
+            'token_type'    => 'Bearer',
+        ]);
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockGetBillingAgreementTokenResponse()
+            )
+        );
+
+        try {
+            $response = $this->client->getBillingAgreementTokenDetails('BA-8A802366G0648845Y');
+        } catch (\Throwable $e) {
+        }
+
+        $this->assertNotEmpty($response);
+        $this->assertArrayHasKey('token_id', $response);
+    }
+
+    #[Test]
+    public function it_can_create_a_billing_agreement(): void
+    {
+        $this->client->setAccessToken([
+            'access_token'  => self::$access_token,
+            'token_type'    => 'Bearer',
+        ]);
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockCreateBillingAgreementResponse()
+            )
+        );
+
+        try {
+            $response = $this->client->setRequestHeader('PayPal-Request-Id', 'some-request-id')->createBillingAgreement('BA-8A802366G0648845Y');
+        } catch (\Throwable $e) {
+        }
+
+        $this->assertNotEmpty($response);
+        $this->assertArrayHasKey('id', $response);
+    }
+
+    #[Test]
+    public function it_can_update_a_billing_agreement(): void
+    {
+        $this->client->setAccessToken([
+            'access_token'  => self::$access_token,
+            'token_type'    => 'Bearer',
+        ]);
+
+        $this->client->setClient(
+            $this->mock_http_client(false)
+        );
+
+        $expectedParams = $this->updateBillingAgreementParams();
+
+        try {
+            $response = $this->client->updateBillingAgreement('BA-8A802366G0648845Y', $expectedParams);
+        } catch (\Throwable $e) {
+        }
+
+        $this->assertEmpty($response);
+    }
+
+    #[Test]
+    public function it_can_show_billing_agreement_details(): void
+    {
+        $this->client->setAccessToken([
+            'access_token'  => self::$access_token,
+            'token_type'    => 'Bearer',
+        ]);
+
+        $this->client->setClient(
+            $this->mock_http_client(
+                $this->mockShowBillingAgreementResponse()
+            )
+        );
+
+        try {
+            $response = $this->client->showBillingAgreementDetails('BA-8A802366G0648845Y');
+        } catch (\Throwable $e) {
+        }
+
+        $this->assertNotEmpty($response);
+        $this->assertArrayHasKey('id', $response);
+    }
+
+    #[Test]
+    public function it_can_cancel_a_billing_agreement(): void
+    {
+        $this->client->setAccessToken([
+            'access_token'  => self::$access_token,
+            'token_type'    => 'Bearer',
+        ]);
+
+        $this->client->setClient(
+            $this->mock_http_client(false)
+        );
+
+        try {
+            $response = $this->client->cancelBillingAgreement('BA-8A802366G0648845Y');
+        } catch (\Throwable $e) {
+        }
+
+        $this->assertEmpty($response);
+    }
+
+    #[Test]
     public function it_can_create_a_billing_plan(): void
     {
         $this->client->setAccessToken([

--- a/tests/MockRequestPayloads.php
+++ b/tests/MockRequestPayloads.php
@@ -4,6 +4,7 @@ namespace Srmklive\PayPal\Tests;
 
 trait MockRequestPayloads
 {
+    use Mocks\Requests\BillingAgreements;
     use Mocks\Requests\BillingPlans;
     use Mocks\Requests\CatalogProducts;
     use Mocks\Requests\Disputes;

--- a/tests/MockResponsePayloads.php
+++ b/tests/MockResponsePayloads.php
@@ -4,6 +4,7 @@ namespace Srmklive\PayPal\Tests;
 
 trait MockResponsePayloads
 {
+    use Mocks\Responses\BillingAgreements;
     use Mocks\Responses\BillingPlans;
     use Mocks\Responses\CatalogProducts;
     use Mocks\Responses\Disputes;

--- a/tests/Mocks/Requests/BillingAgreements.php
+++ b/tests/Mocks/Requests/BillingAgreements.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Srmklive\PayPal\Tests\Mocks\Requests;
+
+use GuzzleHttp\Utils;
+
+trait BillingAgreements
+{
+    /**
+     * @return array
+     */
+    private function createBillingAgreementTokenParams(): array
+    {
+        return Utils::jsonDecode('{
+  "payer": {
+    "payment_method": "PAYPAL"
+  },
+  "plan": {
+    "type": "MERCHANT_INITIATED_BILLING",
+    "merchant_preferences": {
+      "return_url": "https://example.com/return",
+      "cancel_url": "https://example.com/cancel",
+      "notify_url": "https://example.com/notify",
+      "accepted_pymt_type": "INSTANT",
+      "skip_shipping_address": false,
+      "immutable_shipping_address": true
+    }
+  },
+  "description": "Billing Agreement",
+  "shipping_address": {
+    "line1": "1350 North First Street",
+    "city": "San Jose",
+    "state": "CA",
+    "postal_code": "95112",
+    "country_code": "US",
+    "recipient_name": "John Doe"
+  }
+}', true);
+    }
+
+    private function updateBillingAgreementParams(): array
+    {
+        return Utils::jsonDecode('[
+  {
+    "op": "replace",
+    "path": "/",
+    "value": {
+      "description": "Example Billing Agreement",
+      "merchant_custom_data": "INV-001"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/plan/merchant_preferences/",
+    "value": {
+      "notify_url": "https://example.com/notify"
+    }
+  }
+]', true);
+    }
+}

--- a/tests/Mocks/Responses/BillingAgreements.php
+++ b/tests/Mocks/Responses/BillingAgreements.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Srmklive\PayPal\Tests\Mocks\Responses;
+
+use GuzzleHttp\Utils;
+
+trait BillingAgreements
+{
+    /**
+     * @return array
+     */
+    /**
+     * @return array
+     */
+    private function mockCreateBillingAgreementTokenResponse(): array
+    {
+        return Utils::jsonDecode('{
+  "links": [
+    {
+      "href": "https://api-m.sandbox.paypal.com/agreements/approve?ba_token=BA-8A802366G0648845Y",
+      "rel": "approval_url",
+      "method": "POST"
+    },
+    {
+      "href": "https://api-m.sandbox.paypal.com/v1/billing-agreements/BA-8A802366G0648845Y/agreements",
+      "rel": "self",
+      "method": "POST"
+    }
+  ],
+  "token_id": "BA-8A802366G0648845Y"
+}', true);
+    }
+
+    private function mockGetBillingAgreementTokenResponse(): array
+    {
+        return Utils::jsonDecode('{
+  "description": "Billing Agreement",
+  "token_id": "BA-8A802366G0648845Y",
+  "token_status": "PENDING",
+  "skip_shipping_address": false,
+  "immutable_shipping_address": true,
+  "redirect_urls": {
+    "cancel_url": "https://example.com/cancel",
+    "return_url": "https://example.com/return",
+    "notify_url": "https://example.com/notify"
+  },
+  "plan_unit_list": [
+    {
+      "id": "BA-8A802366G0648845Y",
+      "billing_type": "MERCHANT_INITIATED_BILLING"
+    }
+  ],
+  "owner": {
+    "merchant_id": "J6LF2WT3H97J6",
+    "email": "merchant@example.com"
+  }
+}', true);
+    }
+
+    private function mockCreateBillingAgreementResponse(): array
+    {
+        return Utils::jsonDecode('{
+  "id": "B-50V812176H0783741",
+  "state": "ACTIVE",
+  "description": "Billing Agreement",
+  "payer": {
+    "payer_info": {
+      "email": "doe@example.com",
+      "first_name": "John",
+      "last_name": "Doe",
+      "payer_id": "ZU7HZ76P4VL5U"
+    }
+  },
+  "plan": {
+    "type": "MERCHANT_INITIATED_BILLING",
+    "merchant_preferences": {
+      "notify_url": "https://example.com/notify",
+      "accepted_pymt_type": "INSTANT"
+    }
+  },
+  "links": [
+    {
+      "href": "https://api-m.sandbox.paypal.com/v1/billing-agreements/agreements/B-50V812176H0783741/cancel",
+      "rel": "cancel",
+      "method": "POST"
+    },
+    {
+      "href": "https://api-m.sandbox.paypal.com/v1/billing-agreements/agreements/B-50V812176H0783741",
+      "rel": "self",
+      "method": "GET"
+    }
+  ],
+  "merchant": {
+    "payee_info": {
+      "email": "merchant@example.com"
+    }
+  },
+  "create_time": "2017-08-08T07:19:28.000Z",
+  "update_time": "2017-08-08T07:19:28.000Z"
+}', true);
+    }
+
+    private function mockShowBillingAgreementResponse(): array
+    {
+        return Utils::jsonDecode('{
+  "id": "B-50V812176H0783741",
+  "state": "ACTIVE",
+  "description": "Billing Agreement",
+  "payer": {
+    "payer_info": {
+      "email": "doe@example.com",
+      "first_name": "John",
+      "last_name": "Doe",
+      "payer_id": "ZU7HZ76P4VL5U"
+    }
+  },
+  "plan": {
+    "type": "MERCHANT_INITIATED_BILLING",
+    "merchant_preferences": {
+      "notify_url": "https://example.com/notify",
+      "accepted_pymt_type": "INSTANT"
+    }
+  },
+  "links": [
+    {
+      "href": "https://api-m.sandbox.paypal.com/v1/billing-agreements/agreements/B-50V812176H0783741/cancel",
+      "rel": "cancel",
+      "method": "POST"
+    },
+    {
+      "href": "https://api-m.sandbox.paypal.com/v1/billing-agreements/agreements/B-50V812176H0783741",
+      "rel": "self",
+      "method": "GET"
+    }
+  ],
+  "merchant": {
+    "payee_info": {
+      "email": "merchant@example.com"
+    }
+  },
+  "create_time": "2017-08-08T07:19:28.000Z",
+  "update_time": "2017-08-08T07:19:28.000Z"
+}', true);
+    }
+}


### PR DESCRIPTION
Adds functions for the endpoints of the Reference Transactions API.

I also added tests in `tests/Feature/AdapterFeatureTest.php` similar to the tests for the `BillingPlans` PayPalAPI trait.

Sources:
* https://developer.paypal.com/limited-release/reference-transactions/
* https://developer.paypal.com/api/limited-release/reference-transactions/v1/