### PR TITLE
fix: v3.1 audit — state leaks, type hint, CI deprecations, wrong doc links

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,18 +17,15 @@ jobs:
       uses: shivammathur/setup-php@v2
     - name: Get Composer cache directory
       id: composercache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
     - name: Cache Composer dependencies
       uses: actions/cache@v5
       with:
-        php-version: ${{ matrix.php-versions }}
         path: ${{ steps.composercache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
         restore-keys: ${{ runner.os }}-composer-
     - name: Install Composer dependencies
-      env:
-        PHP_VERSION: ${{ matrix.php-versions }}
-      run: composer install --no-progress --prefer-dist --optimize-autoloader $(if [ "$PHP_VERSION" == "8.0" || "$PHP_VERSION" == "8.1" ]; then echo "--ignore-platform-reqs"; fi;)    
+      run: composer install --no-progress --prefer-dist --optimize-autoloader
     - name: Run type checking analysis
       env:
         PHP_VERSION: ${{ matrix.php-versions }}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
          cacheDirectory=".phpunit.cache"

--- a/src/Traits/PayPalAPI/BillingPlans.php
+++ b/src/Traits/PayPalAPI/BillingPlans.php
@@ -62,7 +62,7 @@ trait BillingPlans
      *
      * @throws \Throwable
      *
-     * @see https://developer.paypal.com/docs/api/invoicing/v2/#invoices_update
+     * @see https://developer.paypal.com/docs/api/subscriptions/v1/#plans_patch
      */
     public function updatePlan(string $plan_id, array $data)
     {

--- a/src/Traits/PayPalAPI/BillingPlans/PricingSchemes.php
+++ b/src/Traits/PayPalAPI/BillingPlans/PricingSchemes.php
@@ -40,6 +40,11 @@ trait PricingSchemes
             throw new \RuntimeException('No billing plan set. Call addBillingPlanById() first.');
         }
 
-        return $this->updatePlanPricing($this->billing_plan['id'], $this->pricing_schemes);
+        $response = $this->updatePlanPricing($this->billing_plan['id'], $this->pricing_schemes);
+
+        // Reset so accumulated schemes don't bleed into subsequent calls.
+        $this->pricing_schemes = [];
+
+        return $response;
     }
 }

--- a/src/Traits/PayPalAPI/Identity.php
+++ b/src/Traits/PayPalAPI/Identity.php
@@ -127,7 +127,7 @@ trait Identity
     }
 
     /**
-     * Create a merchant application.
+     * Set account properties / features for a merchant account.
      *
      *
      *
@@ -154,7 +154,7 @@ trait Identity
     }
 
     /**
-     * Create a merchant application.
+     * Deactivate account properties / features for a merchant account.
      *
      *
      *

--- a/src/Traits/PayPalAPI/Invoices.php
+++ b/src/Traits/PayPalAPI/Invoices.php
@@ -328,7 +328,7 @@ trait Invoices
      *
      * @throws \Throwable
      *
-     * @see https://developer.paypal.com/docs/api/invoicing/v2/#invoices_list
+     * @see https://developer.paypal.com/docs/api/invoicing/v2/#invoices_delete
      */
     public function deleteInvoice(string $invoice_id)
     {

--- a/src/Traits/PayPalAPI/InvoicesSearch.php
+++ b/src/Traits/PayPalAPI/InvoicesSearch.php
@@ -33,6 +33,11 @@ trait InvoicesSearch
 
         $this->verb = 'post';
 
-        return $this->doPayPalRequest();
+        $response = $this->doPayPalRequest();
+
+        // Reset filters so a subsequent call on the same instance starts fresh.
+        $this->invoice_search_filters = [];
+
+        return $response;
     }
 }

--- a/src/Traits/PayPalAPI/Subscriptions/Helpers.php
+++ b/src/Traits/PayPalAPI/Subscriptions/Helpers.php
@@ -106,6 +106,11 @@ trait Helpers
         $this->billing_plan = null;
         $this->trial_pricing = [];
         $this->experience_context = [];
+        $this->shipping_address = null;
+        $this->payment_preferences = [];
+        $this->has_setup_fee = false;
+        $this->taxes = null;
+        $this->custom_id = null;
 
         return $subscription;
     }

--- a/src/Traits/PayPalAPI/WebHooks.php
+++ b/src/Traits/PayPalAPI/WebHooks.php
@@ -119,14 +119,13 @@ trait WebHooks
     /**
      * List events for an existing web hook.
      *
-     * @param  string  $web_hook_id
      * @return array<string, mixed>|StreamInterface|string
      *
      * @throws \Throwable
      *
      * @see https://developer.paypal.com/docs/api/webhooks/v1/#webhooks_get
      */
-    public function listWebHookEvents($web_hook_id)
+    public function listWebHookEvents(string $web_hook_id)
     {
         $this->apiEndPoint = "v1/notifications/webhooks/{$web_hook_id}/event-types";
 


### PR DESCRIPTION
## Summary

In-depth audit of the v3.1 branch. All changes are bug fixes — no new features or refactoring.

### Functional bugs (3)

- **`setupSubscription()` state leak** (`Subscriptions/Helpers.php`) — `shipping_address`, `payment_preferences`, `has_setup_fee`, `taxes`, and `custom_id` were never reset after the call. Reusing the same `PayPal` instance for a second subscription silently inherited data from the first. Fixed by resetting all five to their zero values at the end of the method (alongside the existing resets for `product`, `billing_plan`, `trial_pricing`, `experience_context`).

- **`searchInvoices()` filter leak** (`InvoicesSearch.php`) — `$invoice_search_filters` was never cleared after the request. A second call on the same instance would silently reuse the old filters. Fixed by resetting the array to `[]` after `doPayPalRequest()` returns.

- **`processBillingPlanPricingUpdates()` scheme accumulation** (`BillingPlans/PricingSchemes.php`) — `$pricing_schemes` was never cleared after an update. Calling `addPricingScheme()` + `processBillingPlanPricingUpdates()` a second time would send all previously added schemes as well. Fixed by resetting `$pricing_schemes = []` after the update.

### Type-safety bug (1)

- **`listWebHookEvents()` missing type hint** (`WebHooks.php`) — the `$web_hook_id` parameter had no `string` declaration, unlike every other method in the same trait. Added the missing type hint and removed the now-redundant `@param` doc line.

### CI / tooling bugs (2)

- **`phpunit.xml.dist` schema version** — schema URL was pinned to `11.0` while `composer.json` already allows `^12.0`. PHPUnit 12 emits a config-version warning on every run. Updated to `12.0`.

- **`static-analysis.yml` deprecated `::set-output`** — GitHub removed the `::set-output` workflow command; replaced with the `$GITHUB_OUTPUT` environment file. Also removed a dead `--ignore-platform-reqs` shell condition that used `[ a || b ]` (a bash syntax error in single-bracket form) and was unreachable anyway since the matrix only covers PHP ≥ 8.2.

### Documentation bugs (3)

- **`BillingPlans::updatePlan()` `@see` URL** pointed to `invoicing/v2/#invoices_update` — corrected to `subscriptions/v1/#plans_patch`.
- **`Invoices::deleteInvoice()` `@see` URL** pointed to `#invoices_list` — corrected to `#invoices_delete`.
- **`Identity` copy-paste docblocks** — `setAccountProperties()` and `disableAccountProperties()` both said *"Create a merchant application."* Fixed to *"Set account properties…"* and *"Deactivate account properties…"* respectively.

## Test plan

- [ ] Existing test suite passes (`./vendor/bin/pest --ci`)
- [ ] Static analysis clean (`vendor/bin/phpstan`)
- [ ] Verify `setupSubscription()` state is fully reset between calls by running `AdapterCreateSubscriptionHelpersTest`
- [ ] Verify `searchInvoices()` filter reset by confirming a second call without filters uses only the default currency filter