### PR TITLE
feat: add public MockPayPalClient for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,6 +883,58 @@ $provider->deleteWebExperienceProfile('XP-A88A-LYLW-8Y3X-E5ER');
 
 ---
 
+## Testing
+
+Use `MockPayPalClient` to write unit tests against your PayPal integration without hitting the sandbox API:
+
+```php
+use Srmklive\PayPal\Testing\MockPayPalClient;
+
+$mock = new MockPayPalClient();
+$mock->addResponse(['id' => '5O190127TN364715T', 'status' => 'CREATED']);
+
+// mockProvider() returns a ready PayPal instance — credentials and access token pre-set
+$provider = $mock->mockProvider();
+$order = $provider->createOrder($data);
+
+expect($order['id'])->toBe('5O190127TN364715T');
+```
+
+Queue multiple responses in order — one is consumed per API call:
+
+```php
+$mock = new MockPayPalClient();
+$mock->addResponse(['id' => 'ORDER-1', 'status' => 'CREATED']);
+$mock->addResponse(['id' => 'ORDER-2', 'status' => 'CREATED']);
+```
+
+Pass `false` as the body for empty-response operations (e.g. `updateOrder`, which returns 204):
+
+```php
+$mock->addResponse(false, 204);
+```
+
+Inspect what was sent to assert on headers, method, or payload:
+
+```php
+$request = $mock->lastRequest();           // Psr\Http\Message\RequestInterface
+$mock->requests();                         // all captured requests, in order
+$mock->requestCount();                     // int
+
+$request->getHeaderLine('Authorization'); // 'Bearer mock-access-token'
+$request->getMethod();                    // 'POST'
+(string) $request->getUri();              // 'https://api-m.sandbox.paypal.com/v2/checkout/orders'
+```
+
+If you need to inject the mock into a provider you've already constructed, pass it to `setClient()` directly — `MockPayPalClient` implements `Psr\Http\Client\ClientInterface`:
+
+```php
+$provider->setAccessToken(['access_token' => 'mock-token', 'token_type' => 'Bearer']);
+$provider->setClient($mock);
+```
+
+---
+
 ## Maintained by Blendbyte
 
 <a href="https://www.blendbyte.com">

--- a/src/Testing/MockPayPalClient.php
+++ b/src/Testing/MockPayPalClient.php
@@ -2,63 +2,55 @@
 
 namespace Srmklive\PayPal\Testing;
 
-use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Utils;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Srmklive\PayPal\Services\PayPal;
 
-class MockPayPalClient
+class MockPayPalClient implements ClientInterface
 {
-    private MockHandler $handler;
+    /** @var ResponseInterface[] */
+    private array $responseQueue = [];
 
-    /** @var array<int, array{request: RequestInterface, response: \Psr\Http\Message\ResponseInterface}> */
+    /** @var RequestInterface[] */
     private array $history = [];
-
-    private ?GuzzleClient $guzzle = null;
-
-    public function __construct()
-    {
-        $this->handler = new MockHandler();
-    }
 
     /**
      * Queue a response for the next HTTP call.
      *
      * Pass an array for a JSON body, or false for an empty body (e.g. 204 No Content).
+     *
+     * @param array<string, mixed>|false $body
      */
     public function addResponse(array|false $body = [], int $statusCode = 200): static
     {
-        $this->handler->append(new Response(
+        $this->responseQueue[] = new Response(
             $statusCode,
             ['Content-Type' => 'application/json'],
             $body === false ? '' : Utils::jsonEncode($body),
-        ));
+        );
 
         return $this;
     }
 
-    /**
-     * Returns a PSR-18 ClientInterface to pass to PayPal::setClient().
-     */
-    public function getClient(): ClientInterface
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
-        if ($this->guzzle === null) {
-            $stack = HandlerStack::create($this->handler);
-            $stack->push(Middleware::history($this->history));
-            $this->guzzle = new GuzzleClient(['handler' => $stack]);
+        $this->history[] = $request;
+
+        if ($this->responseQueue === []) {
+            throw new \UnderflowException('MockPayPalClient has no more queued responses.');
         }
 
-        return $this->guzzle;
+        return array_shift($this->responseQueue);
     }
 
     /**
-     * Convenience method: wire the mock client into a PayPal provider instance
+     * Convenience method: wire this mock into a PayPal provider instance
      * and pre-set a fake access token so callers skip the auth round-trip.
+     *
+     * @param array<string, mixed> $config
      */
     public function mockProvider(array $config = []): PayPal
     {
@@ -78,7 +70,7 @@ class MockPayPalClient
 
         $provider = new PayPal($config);
         $provider->setAccessToken(['access_token' => 'mock-access-token', 'token_type' => 'Bearer']);
-        $provider->setClient($this->getClient());
+        $provider->setClient($this);
 
         return $provider;
     }
@@ -90,16 +82,16 @@ class MockPayPalClient
      */
     public function requests(): array
     {
-        return array_map(fn ($h) => $h['request'], $this->history);
+        return $this->history;
     }
 
     public function lastRequest(): ?RequestInterface
     {
-        if (empty($this->history)) {
+        if ($this->history === []) {
             return null;
         }
 
-        return end($this->history)['request'];
+        return end($this->history);
     }
 
     public function requestCount(): int

--- a/src/Testing/MockPayPalClient.php
+++ b/src/Testing/MockPayPalClient.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Srmklive\PayPal\Testing;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Utils;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Srmklive\PayPal\Services\PayPal;
+
+class MockPayPalClient
+{
+    private MockHandler $handler;
+
+    /** @var array<int, array{request: RequestInterface, response: \Psr\Http\Message\ResponseInterface}> */
+    private array $history = [];
+
+    private ?GuzzleClient $guzzle = null;
+
+    public function __construct()
+    {
+        $this->handler = new MockHandler();
+    }
+
+    /**
+     * Queue a response for the next HTTP call.
+     *
+     * Pass an array for a JSON body, or false for an empty body (e.g. 204 No Content).
+     */
+    public function addResponse(array|false $body = [], int $statusCode = 200): static
+    {
+        $this->handler->append(new Response(
+            $statusCode,
+            ['Content-Type' => 'application/json'],
+            $body === false ? '' : Utils::jsonEncode($body),
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Returns a PSR-18 ClientInterface to pass to PayPal::setClient().
+     */
+    public function getClient(): ClientInterface
+    {
+        if ($this->guzzle === null) {
+            $stack = HandlerStack::create($this->handler);
+            $stack->push(Middleware::history($this->history));
+            $this->guzzle = new GuzzleClient(['handler' => $stack]);
+        }
+
+        return $this->guzzle;
+    }
+
+    /**
+     * Convenience method: wire the mock client into a PayPal provider instance
+     * and pre-set a fake access token so callers skip the auth round-trip.
+     */
+    public function mockProvider(array $config = []): PayPal
+    {
+        $config = array_merge([
+            'mode' => 'sandbox',
+            'sandbox' => [
+                'client_id' => 'mock-client-id',
+                'client_secret' => 'mock-client-secret',
+                'app_id' => 'APP-MOCK',
+            ],
+            'payment_action' => 'Sale',
+            'currency' => 'USD',
+            'notify_url' => '',
+            'locale' => 'en_US',
+            'validate_ssl' => true,
+        ], $config);
+
+        $provider = new PayPal($config);
+        $provider->setAccessToken(['access_token' => 'mock-access-token', 'token_type' => 'Bearer']);
+        $provider->setClient($this->getClient());
+
+        return $provider;
+    }
+
+    /**
+     * All captured PSR-7 requests, in order.
+     *
+     * @return RequestInterface[]
+     */
+    public function requests(): array
+    {
+        return array_map(fn ($h) => $h['request'], $this->history);
+    }
+
+    public function lastRequest(): ?RequestInterface
+    {
+        if (empty($this->history)) {
+            return null;
+        }
+
+        return end($this->history)['request'];
+    }
+
+    public function requestCount(): int
+    {
+        return count($this->history);
+    }
+}

--- a/tests/Unit/Testing/MockPayPalClientTest.php
+++ b/tests/Unit/Testing/MockPayPalClientTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use Srmklive\PayPal\Testing\MockPayPalClient;
+use Srmklive\PayPal\Tests\MockRequestPayloads;
+
+uses(MockRequestPayloads::class);
+
+describe('MockPayPalClient', function () {
+    it('queues and returns a response', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['id' => '5O190127TN364715T', 'status' => 'CREATED']);
+
+        $provider = $mock->mockProvider();
+        $response = $provider->createOrder($this->createOrderParams());
+
+        expect($response)->toHaveKey('id', '5O190127TN364715T');
+        expect($response)->toHaveKey('status', 'CREATED');
+    });
+
+    it('queues multiple responses in order', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['id' => 'ORDER-1', 'status' => 'CREATED']);
+        $mock->addResponse(['id' => 'ORDER-2', 'status' => 'CREATED']);
+
+        $provider = $mock->mockProvider();
+
+        $first = $provider->createOrder($this->createOrderParams());
+        $second = $provider->createOrder($this->createOrderParams());
+
+        expect($first['id'])->toBe('ORDER-1');
+        expect($second['id'])->toBe('ORDER-2');
+    });
+
+    it('captures request count', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['id' => 'ORDER-1', 'status' => 'CREATED']);
+        $mock->addResponse(['id' => 'ORDER-2', 'status' => 'CREATED']);
+
+        $provider = $mock->mockProvider();
+        $provider->createOrder($this->createOrderParams());
+        $provider->createOrder($this->createOrderParams());
+
+        expect($mock->requestCount())->toBe(2);
+    });
+
+    it('exposes all captured requests', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['id' => 'ORDER-1', 'status' => 'CREATED']);
+
+        $provider = $mock->mockProvider();
+        $provider->createOrder($this->createOrderParams());
+
+        $requests = $mock->requests();
+        expect($requests)->toHaveCount(1);
+        expect($requests[0]->getMethod())->toBe('POST');
+    });
+
+    it('exposes the last request for assertion', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['id' => 'ORDER-1', 'status' => 'CREATED']);
+
+        $provider = $mock->mockProvider();
+        $provider->createOrder($this->createOrderParams());
+
+        $request = $mock->lastRequest();
+        expect($request)->not->toBeNull();
+        expect($request->getHeaderLine('Authorization'))->toBe('Bearer mock-access-token');
+        expect($request->getHeaderLine('Content-Type'))->toBe('application/json');
+    });
+
+    it('returns null for lastRequest when no calls made', function () {
+        $mock = new MockPayPalClient();
+        expect($mock->lastRequest())->toBeNull();
+    });
+
+    it('handles empty body response for no-content operations', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(false, 204);
+
+        $provider = $mock->mockProvider();
+        $response = $provider->updateOrder('5O190127TN364715T', $this->updateOrderParams());
+
+        expect($response)->toBeEmpty();
+    });
+
+    it('sends requests to the correct PayPal endpoint', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['id' => 'ORDER-1', 'status' => 'CREATED']);
+
+        $provider = $mock->mockProvider();
+        $provider->createOrder($this->createOrderParams());
+
+        $uri = $mock->lastRequest()->getUri();
+        expect((string) $uri)->toContain('/v2/checkout/orders');
+    });
+
+    it('accepts custom config via mockProvider', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['id' => 'ORDER-1', 'status' => 'CREATED']);
+
+        $provider = $mock->mockProvider(['currency' => 'EUR']);
+        $provider->createOrder($this->createOrderParams());
+
+        expect($mock->requestCount())->toBe(1);
+    });
+});

--- a/tests/Unit/Testing/MockPayPalClientTest.php
+++ b/tests/Unit/Testing/MockPayPalClientTest.php
@@ -103,4 +103,9 @@ describe('MockPayPalClient', function () {
 
         expect($mock->requestCount())->toBe(1);
     });
+
+    it('throws when sendRequest is called with no queued responses', function () {
+        $mock = new MockPayPalClient();
+        $mock->sendRequest(new \GuzzleHttp\Psr7\Request('GET', 'https://example.com'));
+    })->throws(\UnderflowException::class);
 });


### PR DESCRIPTION
## Summary

- Adds `Srmklive\PayPal\Testing\MockPayPalClient` — a public testing helper that library users can use to write unit tests against their PayPal integration without hitting the sandbox API.
- Adds 9 unit tests covering all public methods of the new class.

## Motivation

Previously the only way to mock PayPal HTTP calls in tests was to reach into the internal `tests/` traits (`MockClientClasses`, `MockResponsePayloads`), which are only available under `autoload-dev` and not designed for external use. Issue #525 ("How I can write tests with this package?") had no clean answer.

## Usage

```php
use Srmklive\PayPal\Testing\MockPayPalClient;

$mock = new MockPayPalClient();
$mock->addResponse(['id' => '5O190127TN364715T', 'status' => 'CREATED']);

// mockProvider() returns a ready PayPal instance with fake credentials
// and access token pre-set — no sandbox round-trip needed
$provider = $mock->mockProvider();
$order = $provider->createOrder($data);

// Inspect what was sent
expect($mock->lastRequest()->getHeaderLine('Authorization'))
    ->toBe('Bearer mock-access-token');
expect($mock->requestCount())->toBe(1);
```

For custom config or when you need the PSR-18 client directly:

```php
$provider = $mock->mockProvider(['currency' => 'EUR']);

// or
$provider->setClient($mock->getClient());
```

## Test plan

- [x] 9 new tests in `tests/Unit/Testing/MockPayPalClientTest.php` — all passing
- [x] Full suite (629 tests) passes without regression