### PR TITLE
feat: add BillingPlanBuilder for fluent billing plan creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A PayPal REST API package for Laravel, also usable as a standalone PHP client wi
 - [PayPal Fastlane](#paypal-fastlane)
 - [Subscription Helpers](#subscription-helpers)
 - [Billing Plans](#billing-plans)
+  - [BillingPlanBuilder](#billingplanbuilder)
 - [Catalog Products](#catalog-products)
 - [Orders](#orders)
 - [Payments](#payments)
@@ -455,6 +456,67 @@ $response = $provider->addBillingPlanById('P-5ML4271244454362WXNWU5NQ')
 ---
 
 ## Billing Plans
+
+### BillingPlanBuilder
+
+Building a billing plan payload by hand is error-prone — cycles need correct sequences, prices must be strings, and the nesting is deep. `BillingPlanBuilder` handles all of that:
+
+```php
+use Srmklive\PayPal\Builders\BillingPlanBuilder;
+
+$response = BillingPlanBuilder::make()
+    ->forProduct('PROD-XXCD1234QWER65782')
+    ->named('Premium Plan', 'Monthly premium access')
+    ->monthly(9.99)
+    ->create($provider);
+```
+
+With a trial period and setup fee:
+
+```php
+$response = BillingPlanBuilder::make()
+    ->forProduct('PROD-XXCD1234QWER65782')
+    ->named('Video Streaming Plan', 'Video Streaming Service basic plan')
+    ->trialMonthly(3.00, totalCycles: 2)   // $3/mo for 2 months
+    ->trialMonthly(6.00, totalCycles: 3)   // $6/mo for 3 months
+    ->monthly(10.00, totalCycles: 12)      // $10/mo for 12 months
+    ->withSetupFee(10.00)
+    ->withTax(10.0)
+    ->create($provider);
+```
+
+Cycles are sequenced automatically in the order they are added. Use `build()` instead of `create()` to get the raw array without making an API call:
+
+```php
+$payload = BillingPlanBuilder::make()
+    ->forProduct('PROD-XXCD1234QWER65782')
+    ->named('Annual Plan')
+    ->annual(99.00)
+    ->withCurrency('EUR')
+    ->withFailureThreshold(5)
+    ->build(); // returns array<string, mixed>
+
+$provider->createPlan($payload);
+```
+
+**Available cycle methods:**
+
+| Method | Interval | Tenure |
+|---|---|---|
+| `daily(price, totalCycles)` | DAY / 1 | REGULAR |
+| `weekly(price, totalCycles)` | WEEK / 1 | REGULAR |
+| `monthly(price, totalCycles)` | MONTH / 1 | REGULAR |
+| `annual(price, totalCycles)` | YEAR / 1 | REGULAR |
+| `trialDaily(price, totalCycles)` | DAY / 1 | TRIAL |
+| `trialWeekly(price, totalCycles)` | WEEK / 1 | TRIAL |
+| `trialMonthly(price, totalCycles)` | MONTH / 1 | TRIAL |
+| `trialAnnual(price, totalCycles)` | YEAR / 1 | TRIAL |
+| `regularCycle(unit, count, price, totalCycles)` | custom | REGULAR |
+| `trialCycle(unit, count, price, totalCycles)` | custom | TRIAL |
+
+`totalCycles: 0` means the cycle repeats indefinitely.
+
+### Raw API
 
 ```php
 // List (page, count, show_total, fields)

--- a/src/Builders/BillingPlanBuilder.php
+++ b/src/Builders/BillingPlanBuilder.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace Srmklive\PayPal\Builders;
+
+use Psr\Http\Message\StreamInterface;
+use Srmklive\PayPal\Services\PayPal;
+
+final class BillingPlanBuilder
+{
+    private const VALID_INTERVALS = ['DAY', 'WEEK', 'MONTH', 'YEAR'];
+
+    private const VALID_FAILURE_ACTIONS = ['CONTINUE', 'CANCEL_SUBSCRIPTION'];
+
+    private string $productId = '';
+
+    private string $name = '';
+
+    private string $description = '';
+
+    private string $currency = 'USD';
+
+    /**
+     * @var list<array{tenure_type: string, interval_unit: string, interval_count: int, price: float, total_cycles: int}>
+     */
+    private array $cycles = [];
+
+    private ?float $setupFeeAmount = null;
+
+    private string $failureAction = 'CONTINUE';
+
+    private int $failureThreshold = 3;
+
+    /** @var array<string, mixed>|null */
+    private ?array $taxes = null;
+
+    public static function make(): static
+    {
+        return new static();
+    }
+
+    public function forProduct(string $productId): static
+    {
+        $this->productId = $productId;
+
+        return $this;
+    }
+
+    public function named(string $name, string $description = ''): static
+    {
+        $this->name = $name;
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function withCurrency(string $currency): static
+    {
+        $this->currency = strtoupper($currency);
+
+        return $this;
+    }
+
+    public function withFailureThreshold(int $threshold): static
+    {
+        $this->failureThreshold = $threshold;
+
+        return $this;
+    }
+
+    public function withSetupFee(float $amount, string $failureAction = 'CONTINUE'): static
+    {
+        if (! in_array($failureAction, self::VALID_FAILURE_ACTIONS, true)) {
+            throw new \InvalidArgumentException('Failure action must be one of: '.implode(', ', self::VALID_FAILURE_ACTIONS));
+        }
+
+        $this->setupFeeAmount = $amount;
+        $this->failureAction = $failureAction;
+
+        return $this;
+    }
+
+    public function withTax(float $percentage, bool $inclusive = false): static
+    {
+        $this->taxes = [
+            'percentage' => bcdiv((string) $percentage, '1', 2),
+            'inclusive' => $inclusive,
+        ];
+
+        return $this;
+    }
+
+    // ── Generic cycle adders ──────────────────────────────────────────────────
+
+    public function trialCycle(string $intervalUnit, int $intervalCount, float $price, int $totalCycles = 1): static
+    {
+        $this->validateInterval($intervalUnit);
+
+        $this->cycles[] = [
+            'tenure_type' => 'TRIAL',
+            'interval_unit' => strtoupper($intervalUnit),
+            'interval_count' => $intervalCount,
+            'price' => $price,
+            'total_cycles' => $totalCycles,
+        ];
+
+        return $this;
+    }
+
+    public function regularCycle(string $intervalUnit, int $intervalCount, float $price, int $totalCycles = 0): static
+    {
+        $this->validateInterval($intervalUnit);
+
+        $this->cycles[] = [
+            'tenure_type' => 'REGULAR',
+            'interval_unit' => strtoupper($intervalUnit),
+            'interval_count' => $intervalCount,
+            'price' => $price,
+            'total_cycles' => $totalCycles,
+        ];
+
+        return $this;
+    }
+
+    // ── Regular shortcuts ─────────────────────────────────────────────────────
+
+    public function daily(float $price, int $totalCycles = 0): static
+    {
+        return $this->regularCycle('DAY', 1, $price, $totalCycles);
+    }
+
+    public function weekly(float $price, int $totalCycles = 0): static
+    {
+        return $this->regularCycle('WEEK', 1, $price, $totalCycles);
+    }
+
+    public function monthly(float $price, int $totalCycles = 0): static
+    {
+        return $this->regularCycle('MONTH', 1, $price, $totalCycles);
+    }
+
+    public function annual(float $price, int $totalCycles = 0): static
+    {
+        return $this->regularCycle('YEAR', 1, $price, $totalCycles);
+    }
+
+    // ── Trial shortcuts ───────────────────────────────────────────────────────
+
+    public function trialDaily(float $price, int $totalCycles = 1): static
+    {
+        return $this->trialCycle('DAY', 1, $price, $totalCycles);
+    }
+
+    public function trialWeekly(float $price, int $totalCycles = 1): static
+    {
+        return $this->trialCycle('WEEK', 1, $price, $totalCycles);
+    }
+
+    public function trialMonthly(float $price, int $totalCycles = 1): static
+    {
+        return $this->trialCycle('MONTH', 1, $price, $totalCycles);
+    }
+
+    public function trialAnnual(float $price, int $totalCycles = 1): static
+    {
+        return $this->trialCycle('YEAR', 1, $price, $totalCycles);
+    }
+
+    // ── Terminal methods ──────────────────────────────────────────────────────
+
+    /**
+     * Build the plan payload without making an API call.
+     *
+     * @return array<string, mixed>
+     */
+    public function build(): array
+    {
+        $billingCycles = [];
+
+        foreach ($this->cycles as $i => $cycle) {
+            $billingCycles[] = [
+                'frequency' => [
+                    'interval_unit' => $cycle['interval_unit'],
+                    'interval_count' => $cycle['interval_count'],
+                ],
+                'tenure_type' => $cycle['tenure_type'],
+                'sequence' => $i + 1,
+                'total_cycles' => $cycle['total_cycles'],
+                'pricing_scheme' => [
+                    'fixed_price' => [
+                        'value' => bcdiv((string) $cycle['price'], '1', 2),
+                        'currency_code' => $this->currency,
+                    ],
+                ],
+            ];
+        }
+
+        $paymentPreferences = [
+            'auto_bill_outstanding' => true,
+            'setup_fee_failure_action' => $this->failureAction,
+            'payment_failure_threshold' => $this->failureThreshold,
+        ];
+
+        if ($this->setupFeeAmount !== null) {
+            $paymentPreferences['setup_fee'] = [
+                'value' => bcdiv((string) $this->setupFeeAmount, '1', 2),
+                'currency_code' => $this->currency,
+            ];
+        }
+
+        $plan = [
+            'product_id' => $this->productId,
+            'name' => $this->name,
+            'status' => 'ACTIVE',
+            'billing_cycles' => $billingCycles,
+            'payment_preferences' => $paymentPreferences,
+        ];
+
+        if ($this->description !== '') {
+            $plan['description'] = $this->description;
+        }
+
+        if ($this->taxes !== null) {
+            $plan['taxes'] = $this->taxes;
+        }
+
+        return $plan;
+    }
+
+    /**
+     * Build the payload and call createPlan() on the given provider.
+     *
+     * @return array<string, mixed>|StreamInterface|string
+     *
+     * @throws \Throwable
+     */
+    public function create(PayPal $provider): array|StreamInterface|string
+    {
+        return $provider->createPlan($this->build());
+    }
+
+    private function validateInterval(string $intervalUnit): void
+    {
+        if (! in_array(strtoupper($intervalUnit), self::VALID_INTERVALS, true)) {
+            throw new \InvalidArgumentException(
+                'Interval unit must be one of: '.implode(', ', self::VALID_INTERVALS)
+            );
+        }
+    }
+}

--- a/tests/Unit/Builders/BillingPlanBuilderTest.php
+++ b/tests/Unit/Builders/BillingPlanBuilderTest.php
@@ -1,0 +1,295 @@
+<?php
+
+use Srmklive\PayPal\Builders\BillingPlanBuilder;
+use Srmklive\PayPal\Testing\MockPayPalClient;
+use Srmklive\PayPal\Tests\MockResponsePayloads;
+
+uses(MockResponsePayloads::class);
+
+describe('BillingPlanBuilder', function () {
+
+    // ── build() structure ─────────────────────────────────────────────────────
+
+    it('builds a simple monthly plan', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('PROD-XXCD1234QWER65782')
+            ->named('Basic Plan', 'A basic monthly plan')
+            ->monthly(9.99)
+            ->build();
+
+        expect($plan['product_id'])->toBe('PROD-XXCD1234QWER65782');
+        expect($plan['name'])->toBe('Basic Plan');
+        expect($plan['description'])->toBe('A basic monthly plan');
+        expect($plan['status'])->toBe('ACTIVE');
+        expect($plan['billing_cycles'])->toHaveCount(1);
+
+        $cycle = $plan['billing_cycles'][0];
+        expect($cycle['tenure_type'])->toBe('REGULAR');
+        expect($cycle['sequence'])->toBe(1);
+        expect($cycle['total_cycles'])->toBe(0);
+        expect($cycle['frequency']['interval_unit'])->toBe('MONTH');
+        expect($cycle['frequency']['interval_count'])->toBe(1);
+        expect($cycle['pricing_scheme']['fixed_price']['value'])->toBe('9.99');
+        expect($cycle['pricing_scheme']['fixed_price']['currency_code'])->toBe('USD');
+    });
+
+    it('omits description when not provided', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('PROD-XXX')
+            ->named('No Description Plan')
+            ->monthly(5.00)
+            ->build();
+
+        expect($plan)->not->toHaveKey('description');
+    });
+
+    it('auto-sequences multiple cycles in addition order', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('PROD-XXX')
+            ->named('Tiered Plan')
+            ->trialMonthly(3.00, 2)
+            ->trialMonthly(6.00, 3)
+            ->monthly(10.00, 12)
+            ->build();
+
+        $cycles = $plan['billing_cycles'];
+        expect($cycles)->toHaveCount(3);
+
+        expect($cycles[0]['sequence'])->toBe(1);
+        expect($cycles[0]['tenure_type'])->toBe('TRIAL');
+        expect($cycles[0]['pricing_scheme']['fixed_price']['value'])->toBe('3.00');
+        expect($cycles[0]['total_cycles'])->toBe(2);
+
+        expect($cycles[1]['sequence'])->toBe(2);
+        expect($cycles[1]['tenure_type'])->toBe('TRIAL');
+        expect($cycles[1]['pricing_scheme']['fixed_price']['value'])->toBe('6.00');
+        expect($cycles[1]['total_cycles'])->toBe(3);
+
+        expect($cycles[2]['sequence'])->toBe(3);
+        expect($cycles[2]['tenure_type'])->toBe('REGULAR');
+        expect($cycles[2]['pricing_scheme']['fixed_price']['value'])->toBe('10.00');
+        expect($cycles[2]['total_cycles'])->toBe(12);
+    });
+
+    it('formats prices to two decimal places', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('PROD-XXX')
+            ->named('Plan')
+            ->monthly(10.0)
+            ->build();
+
+        expect($plan['billing_cycles'][0]['pricing_scheme']['fixed_price']['value'])->toBe('10.00');
+    });
+
+    // ── Interval shortcuts ────────────────────────────────────────────────────
+
+    it('daily() sets DAY interval', function () {
+        $plan = BillingPlanBuilder::make()->forProduct('X')->named('P')->daily(1.00)->build();
+        expect($plan['billing_cycles'][0]['frequency']['interval_unit'])->toBe('DAY');
+    });
+
+    it('weekly() sets WEEK interval', function () {
+        $plan = BillingPlanBuilder::make()->forProduct('X')->named('P')->weekly(5.00)->build();
+        expect($plan['billing_cycles'][0]['frequency']['interval_unit'])->toBe('WEEK');
+    });
+
+    it('annual() sets YEAR interval', function () {
+        $plan = BillingPlanBuilder::make()->forProduct('X')->named('P')->annual(99.00)->build();
+        expect($plan['billing_cycles'][0]['frequency']['interval_unit'])->toBe('YEAR');
+    });
+
+    it('trial shortcuts set TRIAL tenure_type', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('X')->named('P')
+            ->trialWeekly(2.00)
+            ->trialAnnual(20.00)
+            ->build();
+
+        expect($plan['billing_cycles'][0]['tenure_type'])->toBe('TRIAL');
+        expect($plan['billing_cycles'][0]['frequency']['interval_unit'])->toBe('WEEK');
+        expect($plan['billing_cycles'][1]['tenure_type'])->toBe('TRIAL');
+        expect($plan['billing_cycles'][1]['frequency']['interval_unit'])->toBe('YEAR');
+    });
+
+    it('trialDaily() defaults to totalCycles 1', function () {
+        $plan = BillingPlanBuilder::make()->forProduct('X')->named('P')->trialDaily(0.00)->build();
+        expect($plan['billing_cycles'][0]['total_cycles'])->toBe(1);
+    });
+
+    // ── regularCycle / trialCycle with custom intervals ───────────────────────
+
+    it('regularCycle() accepts custom interval count', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('X')->named('P')
+            ->regularCycle('MONTH', 3, 25.00)
+            ->build();
+
+        expect($plan['billing_cycles'][0]['frequency']['interval_count'])->toBe(3);
+        expect($plan['billing_cycles'][0]['frequency']['interval_unit'])->toBe('MONTH');
+    });
+
+    it('accepts lowercase interval unit', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('X')->named('P')
+            ->regularCycle('month', 1, 9.99)
+            ->build();
+
+        expect($plan['billing_cycles'][0]['frequency']['interval_unit'])->toBe('MONTH');
+    });
+
+    it('throws on invalid interval unit', function () {
+        BillingPlanBuilder::make()->regularCycle('FORTNIGHT', 1, 9.99);
+    })->throws(\InvalidArgumentException::class);
+
+    it('throws on invalid interval unit in trialCycle', function () {
+        BillingPlanBuilder::make()->trialCycle('QUARTER', 1, 9.99);
+    })->throws(\InvalidArgumentException::class);
+
+    // ── withSetupFee() ────────────────────────────────────────────────────────
+
+    it('includes setup fee in payment_preferences', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('X')->named('P')
+            ->monthly(10.00)
+            ->withSetupFee(5.00)
+            ->build();
+
+        $prefs = $plan['payment_preferences'];
+        expect($prefs)->toHaveKey('setup_fee');
+        expect($prefs['setup_fee']['value'])->toBe('5.00');
+        expect($prefs['setup_fee']['currency_code'])->toBe('USD');
+    });
+
+    it('omits setup_fee from payment_preferences when not set', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('X')->named('P')
+            ->monthly(10.00)
+            ->build();
+
+        expect($plan['payment_preferences'])->not->toHaveKey('setup_fee');
+    });
+
+    it('setup_fee respects currency set via withCurrency()', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('X')->named('P')
+            ->withCurrency('EUR')
+            ->monthly(10.00)
+            ->withSetupFee(5.00)
+            ->build();
+
+        expect($plan['payment_preferences']['setup_fee']['currency_code'])->toBe('EUR');
+    });
+
+    it('withSetupFee accepts CANCEL_SUBSCRIPTION failure action', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('X')->named('P')
+            ->monthly(10.00)
+            ->withSetupFee(5.00, 'CANCEL_SUBSCRIPTION')
+            ->build();
+
+        expect($plan['payment_preferences']['setup_fee_failure_action'])->toBe('CANCEL_SUBSCRIPTION');
+    });
+
+    it('throws on invalid setup fee failure action', function () {
+        BillingPlanBuilder::make()->withSetupFee(5.00, 'INVALID');
+    })->throws(\InvalidArgumentException::class);
+
+    // ── withTax() ─────────────────────────────────────────────────────────────
+
+    it('includes taxes when set', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('X')->named('P')
+            ->monthly(10.00)
+            ->withTax(10.0)
+            ->build();
+
+        expect($plan)->toHaveKey('taxes');
+        expect($plan['taxes']['percentage'])->toBe('10.00');
+        expect($plan['taxes']['inclusive'])->toBeFalse();
+    });
+
+    it('withTax supports inclusive flag', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('X')->named('P')
+            ->monthly(10.00)
+            ->withTax(7.5, true)
+            ->build();
+
+        expect($plan['taxes']['inclusive'])->toBeTrue();
+        expect($plan['taxes']['percentage'])->toBe('7.50');
+    });
+
+    it('omits taxes key when not set', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('X')->named('P')
+            ->monthly(10.00)
+            ->build();
+
+        expect($plan)->not->toHaveKey('taxes');
+    });
+
+    // ── withFailureThreshold() ────────────────────────────────────────────────
+
+    it('sets custom payment failure threshold', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('X')->named('P')
+            ->monthly(10.00)
+            ->withFailureThreshold(5)
+            ->build();
+
+        expect($plan['payment_preferences']['payment_failure_threshold'])->toBe(5);
+    });
+
+    it('defaults payment_failure_threshold to 3', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('X')->named('P')
+            ->monthly(10.00)
+            ->build();
+
+        expect($plan['payment_preferences']['payment_failure_threshold'])->toBe(3);
+    });
+
+    // ── withCurrency() ────────────────────────────────────────────────────────
+
+    it('uses custom currency in billing cycles', function () {
+        $plan = BillingPlanBuilder::make()
+            ->forProduct('X')->named('P')
+            ->withCurrency('eur')
+            ->monthly(10.00)
+            ->build();
+
+        expect($plan['billing_cycles'][0]['pricing_scheme']['fixed_price']['currency_code'])->toBe('EUR');
+    });
+
+    // ── make() factory ────────────────────────────────────────────────────────
+
+    it('make() returns a new builder instance', function () {
+        $a = BillingPlanBuilder::make();
+        $b = BillingPlanBuilder::make();
+        expect($a)->not->toBe($b);
+    });
+
+    // ── create() ─────────────────────────────────────────────────────────────
+
+    it('create() calls createPlan on the provider with the built payload', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse($this->mockCreatePlansResponse());
+
+        $provider = $mock->mockProvider();
+
+        $response = BillingPlanBuilder::make()
+            ->forProduct('PROD-XXCD1234QWER65782')
+            ->named('Video Streaming Service Plan', 'Video Streaming Service basic plan')
+            ->trialMonthly(3.00, 2)
+            ->trialMonthly(6.00, 3)
+            ->monthly(10.00, 12)
+            ->withSetupFee(10.00)
+            ->withTax(10.0)
+            ->create($provider);
+
+        expect($response)->toHaveKey('id', 'P-5ML4271244454362WXNWU5NQ');
+        expect($mock->requestCount())->toBe(1);
+        expect($mock->lastRequest()->getMethod())->toBe('POST');
+        expect((string) $mock->lastRequest()->getUri())->toContain('v1/billing/plans');
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `Srmklive\PayPal\Builders\BillingPlanBuilder` — a fluent builder that eliminates the error-prone manual construction of PayPal billing plan payloads (issue #599).
- Adds 26 unit tests covering all methods, edge cases, and the `create()` API round-trip.
- Adds a `BillingPlanBuilder` section to the README under Billing Plans.

## Motivation

Building a billing plan payload by hand requires knowing the exact nested structure for `billing_cycles`, `frequency`, `pricing_scheme`, `payment_preferences`, and `taxes` — and manually tracking sequence numbers across trial and regular cycles. This builder handles all of it fluently.

## Usage

```php
use Srmklive\PayPal\Builders\BillingPlanBuilder;

// Simple monthly plan
BillingPlanBuilder::make()
    ->forProduct('PROD-XXCD1234QWER65782')
    ->named('Premium Plan', 'Monthly premium access')
    ->monthly(9.99)
    ->create($provider);

// Tiered plan with two trial phases, setup fee, and tax
BillingPlanBuilder::make()
    ->forProduct('PROD-XXCD1234QWER65782')
    ->named('Video Streaming Plan', 'Video Streaming Service basic plan')
    ->trialMonthly(3.00, totalCycles: 2)
    ->trialMonthly(6.00, totalCycles: 3)
    ->monthly(10.00, totalCycles: 12)
    ->withSetupFee(10.00)
    ->withTax(10.0)
    ->create($provider);

// Build payload without API call (for inspection or custom modification)
$payload = BillingPlanBuilder::make()
    ->forProduct('PROD-XXCD1234QWER65782')
    ->named('Annual Plan')
    ->annual(99.00)
    ->withCurrency('EUR')
    ->build();
```

## Design notes

- Cycles are sequenced automatically in the order they are added — no manual `sequence` tracking needed.
- `build()` returns `array<string, mixed>` without touching the API; `create(PayPal $provider)` calls `createPlan()` directly.
- Prices are formatted to two decimal places via `bcdiv()`, consistent with the rest of the library.
- Class is `final` — not designed for extension.
- PHPStan level 8 clean.

## Test plan

- [x] 26 unit tests in `tests/Unit/Builders/BillingPlanBuilderTest.php` — all passing
- [x] Full suite (656 tests) passes without regression
- [x] PHPStan level 8 — no errors