### PR TITLE
feat: extend retry middleware to handle 429 and honour Retry-After

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ return [
     'validate_ssl'    => env('PAYPAL_VALIDATE_SSL', true),
     'timeout'         => env('PAYPAL_TIMEOUT', 30),         // total request timeout (seconds)
     'connect_timeout' => env('PAYPAL_CONNECT_TIMEOUT', 10), // connection timeout (seconds)
-    'max_retries'     => env('PAYPAL_MAX_RETRIES', 2),      // retries on 5xx / network errors (0 to disable)
+    'max_retries'     => env('PAYPAL_MAX_RETRIES', 2),      // retries on 5xx / 429 / network errors (0 to disable)
 ];
 ```
 
@@ -260,6 +260,16 @@ $provider->setClient(new Psr18Client());
 Pass `null` (or call with no argument) to restore the default Guzzle client with the configured timeout and retry middleware.
 
 > **Note:** The built-in retry middleware runs only on the default Guzzle client. When you inject a custom client, handle retries in that client's own middleware stack.
+
+### Retry Behaviour
+
+The default Guzzle client automatically retries failed requests up to `max_retries` times (default: 2) for:
+
+- **5xx server errors** — PayPal-side failures (500, 502, 503, …)
+- **429 Too Many Requests** — rate-limit responses; the `Retry-After` header is read and honoured when present
+- **Network/connection errors** — DNS failures, connection refused, etc.
+
+The delay between attempts uses exponential backoff (500 ms → 1 s → 2 s → 4 s, capped at 8 s) unless a `Retry-After` header overrides it. Set `max_retries` to `0` to disable retries entirely.
 
 ---
 

--- a/src/Services/RetryPolicy.php
+++ b/src/Services/RetryPolicy.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Srmklive\PayPal\Services;
+
+use Closure;
+use GuzzleHttp\Exception\ConnectException;
+use Psr\Http\Message\ResponseInterface;
+
+final class RetryPolicy
+{
+    /** @return Closure(int, mixed, mixed, mixed): bool */
+    public static function decider(int $maxRetries): Closure
+    {
+        return static function (int $retries, mixed $request, mixed $response, mixed $exception) use ($maxRetries): bool {
+            if ($retries >= $maxRetries) {
+                return false;
+            }
+
+            return $exception instanceof ConnectException
+                || ($response instanceof ResponseInterface && (
+                    $response->getStatusCode() >= 500
+                    || $response->getStatusCode() === 429
+                ));
+        };
+    }
+
+    /** @return Closure(int, mixed): int */
+    public static function delay(): Closure
+    {
+        return static function (int $retries, mixed $response): int {
+            if (
+                $response instanceof ResponseInterface
+                && $response->getStatusCode() === 429
+                && $response->hasHeader('Retry-After')
+            ) {
+                return max(0, (int) $response->getHeaderLine('Retry-After')) * 1000;
+            }
+
+            // Exponential backoff: 500ms, 1s, 2s, 4s — capped at 8s.
+            return (int) min(500 * (2 ** ($retries - 1)), 8000);
+        };
+    }
+}

--- a/src/Traits/PayPalHttpClient.php
+++ b/src/Traits/PayPalHttpClient.php
@@ -3,9 +3,9 @@
 namespace Srmklive\PayPal\Traits;
 
 use Srmklive\PayPal\Exceptions\PayPalApiException;
+use Srmklive\PayPal\Services\RetryPolicy;
 use Srmklive\PayPal\Services\Str;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\HttpFactory;
@@ -13,7 +13,6 @@ use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Utils;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
@@ -180,18 +179,8 @@ trait PayPalHttpClient
 
         if ($maxRetries > 0) {
             $stack->push(Middleware::retry(
-                static function (int $retries, mixed $request, mixed $response, mixed $exception) use ($maxRetries): bool {
-                    if ($retries >= $maxRetries) {
-                        return false; // @codeCoverageIgnore
-                    }
-
-                    return $exception instanceof ConnectException
-                        || ($response instanceof ResponseInterface && $response->getStatusCode() >= 500);
-                },
-                static function (int $retries): int {
-                    // Exponential backoff: 500ms, 1s, 2s, 4s — capped at 8s.
-                    return (int) min(500 * (2 ** ($retries - 1)), 8000); // @codeCoverageIgnore
-                }
+                RetryPolicy::decider($maxRetries),
+                RetryPolicy::delay()
             ));
         }
 

--- a/tests/Unit/Services/RetryPolicyTest.php
+++ b/tests/Unit/Services/RetryPolicyTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Srmklive\PayPal\Services\RetryPolicy;
+
+describe('RetryPolicy::decider', function () {
+    it('retries on 429 Too Many Requests', function () {
+        $decider = RetryPolicy::decider(3);
+        $response = new Response(429);
+
+        expect($decider(0, null, $response, null))->toBeTrue();
+    });
+
+    it('retries on 500 Internal Server Error', function () {
+        $decider = RetryPolicy::decider(3);
+        $response = new Response(500);
+
+        expect($decider(0, null, $response, null))->toBeTrue();
+    });
+
+    it('retries on 503 Service Unavailable', function () {
+        $decider = RetryPolicy::decider(3);
+        $response = new Response(503);
+
+        expect($decider(0, null, $response, null))->toBeTrue();
+    });
+
+    it('retries on ConnectException', function () {
+        $decider = RetryPolicy::decider(3);
+        $exception = new ConnectException('Connection refused', new Request('GET', '/'));
+
+        expect($decider(0, null, null, $exception))->toBeTrue();
+    });
+
+    it('does not retry on 200 OK', function () {
+        $decider = RetryPolicy::decider(3);
+        $response = new Response(200);
+
+        expect($decider(0, null, $response, null))->toBeFalse();
+    });
+
+    it('does not retry on 400 Bad Request', function () {
+        $decider = RetryPolicy::decider(3);
+        $response = new Response(400);
+
+        expect($decider(0, null, $response, null))->toBeFalse();
+    });
+
+    it('stops retrying when maxRetries is reached', function () {
+        $decider = RetryPolicy::decider(3);
+        $response = new Response(429);
+
+        expect($decider(3, null, $response, null))->toBeFalse();
+    });
+
+    it('stops retrying when maxRetries is reached for 500', function () {
+        $decider = RetryPolicy::decider(2);
+        $response = new Response(500);
+
+        expect($decider(2, null, $response, null))->toBeFalse();
+    });
+
+    it('returns false when no response and no exception', function () {
+        $decider = RetryPolicy::decider(3);
+
+        expect($decider(0, null, null, null))->toBeFalse();
+    });
+});
+
+describe('RetryPolicy::delay', function () {
+    it('reads Retry-After header on 429 and returns milliseconds', function () {
+        $delay = RetryPolicy::delay();
+        $response = new Response(429, ['Retry-After' => '5']);
+
+        expect($delay(1, $response))->toBe(5000);
+    });
+
+    it('returns 0ms for Retry-After: 0', function () {
+        $delay = RetryPolicy::delay();
+        $response = new Response(429, ['Retry-After' => '0']);
+
+        expect($delay(1, $response))->toBe(0);
+    });
+
+    it('returns 0ms minimum when Retry-After is negative', function () {
+        $delay = RetryPolicy::delay();
+        $response = new Response(429, ['Retry-After' => '-10']);
+
+        expect($delay(1, $response))->toBe(0);
+    });
+
+    it('falls back to exponential backoff when response is not 429', function () {
+        $delay = RetryPolicy::delay();
+        $response = new Response(500);
+
+        // retries=1 → 500 * 2^0 = 500ms
+        expect($delay(1, $response))->toBe(500);
+    });
+
+    it('falls back to exponential backoff when response has no Retry-After', function () {
+        $delay = RetryPolicy::delay();
+        $response = new Response(429);
+
+        // retries=1 → 500ms (no Retry-After header)
+        expect($delay(1, $response))->toBe(500);
+    });
+
+    it('falls back to exponential backoff when response is null', function () {
+        $delay = RetryPolicy::delay();
+
+        // retries=2 → 500 * 2^1 = 1000ms
+        expect($delay(2, null))->toBe(1000);
+    });
+
+    it('exponential backoff caps at 8000ms', function () {
+        $delay = RetryPolicy::delay();
+
+        // retries=5 → 500 * 2^4 = 8000ms
+        expect($delay(5, null))->toBe(8000);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `429 Too Many Requests` to the retry condition alongside existing `5xx` and `ConnectException` retries
- Extracts retry logic into a new `RetryPolicy` final class (`src/Services/RetryPolicy.php`) with two static factory methods — `decider()` and `delay()` — making the closures directly unit-testable
- `delay()` reads the `Retry-After` response header on 429 responses and converts it to milliseconds; falls back to exponential backoff (500 ms → 1 s → 2 s → 4 s, capped at 8 s) for all other cases
- Updates README with a "Retry Behaviour" subsection documenting what triggers retries and how `Retry-After` is honoured

## Changes

| File | Change |
|------|--------|
| `src/Services/RetryPolicy.php` | New — `final class` with `decider(int $maxRetries)` and `delay()` |
| `src/Traits/PayPalHttpClient.php` | Uses `RetryPolicy::decider()` / `RetryPolicy::delay()`; removes now-unused imports |
| `tests/Unit/Services/RetryPolicyTest.php` | New — 16 unit tests calling closures directly (no real sleeping) |
| `README.md` | Updated config comment; new "Retry Behaviour" subsection |

## Test plan

- [ ] `RetryPolicy::decider` retries on 429, 500, 503, `ConnectException`; stops at `maxRetries`; does not retry on 200/400
- [ ] `RetryPolicy::delay` returns `Retry-After` value × 1000 ms on 429; clamps negative values to 0; falls back to exponential backoff for 5xx, no header, or null response; caps at 8000 ms
- [ ] Full suite passes with no regressions (672 tests)
- [ ] PHPStan level 8 clean