### PR TITLE
feat: add reactivateSubscription() and isSubscriptionActive() helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,12 @@ $provider->suspendSubscription('I-BW452GLLEP1G', 'Item out of stock');
 $provider->captureSubscriptionPayment('I-BW452GLLEP1G', 'Balance reached limit', 100);
 $provider->reviseSubscription('I-BW452GLLEP1G', $data);
 $provider->listSubscriptionTransactions('I-BW452GLLEP1G', '2024-01-01T00:00:00Z', '2024-12-31T23:59:59Z');
+
+// Lifecycle helpers
+$provider->reactivateSubscription('I-BW452GLLEP1G');                          // default reason
+$provider->reactivateSubscription('I-BW452GLLEP1G', 'Customer requested');   // custom reason
+
+$isActive = $provider->isSubscriptionActive('I-BW452GLLEP1G'); // bool
 ```
 
 ---

--- a/src/Traits/PayPalAPI/Subscriptions.php
+++ b/src/Traits/PayPalAPI/Subscriptions.php
@@ -123,6 +123,36 @@ trait Subscriptions
     }
 
     /**
+     * Reactivate a suspended subscription with an optional reason.
+     *
+     * Convenience wrapper around activateSubscription() for the common
+     * "resume after suspend" case — the reason defaults to a sensible value
+     * so callers do not need to supply one.
+     *
+     * @return array<string, mixed>|StreamInterface|string
+     *
+     * @throws \Throwable
+     *
+     * @see https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_activate
+     */
+    public function reactivateSubscription(string $subscription_id, string $reason = 'Reactivating subscription'): array|StreamInterface|string
+    {
+        return $this->activateSubscription($subscription_id, $reason);
+    }
+
+    /**
+     * Return true if the subscription's current status is ACTIVE.
+     *
+     * @throws \Throwable
+     */
+    public function isSubscriptionActive(string $subscription_id): bool
+    {
+        $details = $this->showSubscriptionDetails($subscription_id);
+
+        return is_array($details) && ($details['status'] ?? '') === 'ACTIVE';
+    }
+
+    /**
      * Suspend an existing subscription.
      *
      *

--- a/tests/Unit/Adapter/SubscriptionLifecycleHelpersTest.php
+++ b/tests/Unit/Adapter/SubscriptionLifecycleHelpersTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Srmklive\PayPal\Testing\MockPayPalClient;
+use Srmklive\PayPal\Tests\MockResponsePayloads;
+
+uses(MockResponsePayloads::class);
+
+describe('reactivateSubscription', function () {
+    it('calls activateSubscription with default reason', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(false, 204);
+
+        $provider = $mock->mockProvider();
+        $provider->reactivateSubscription('I-BW452GLLEP1G');
+
+        expect($mock->requestCount())->toBe(1);
+        expect($mock->lastRequest()->getMethod())->toBe('POST');
+        expect((string) $mock->lastRequest()->getUri())->toContain('v1/billing/subscriptions/I-BW452GLLEP1G/activate');
+
+        $body = json_decode((string) $mock->lastRequest()->getBody(), true);
+        expect($body['reason'])->toBe('Reactivating subscription');
+    });
+
+    it('calls activateSubscription with a custom reason', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(false, 204);
+
+        $provider = $mock->mockProvider();
+        $provider->reactivateSubscription('I-BW452GLLEP1G', 'Customer requested resume');
+
+        $body = json_decode((string) $mock->lastRequest()->getBody(), true);
+        expect($body['reason'])->toBe('Customer requested resume');
+    });
+});
+
+describe('isSubscriptionActive', function () {
+    it('returns true when subscription status is ACTIVE', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['id' => 'I-BW452GLLEP1G', 'status' => 'ACTIVE']);
+
+        $provider = $mock->mockProvider();
+
+        expect($provider->isSubscriptionActive('I-BW452GLLEP1G'))->toBeTrue();
+        expect($mock->lastRequest()->getMethod())->toBe('GET');
+        expect((string) $mock->lastRequest()->getUri())->toContain('v1/billing/subscriptions/I-BW452GLLEP1G');
+    });
+
+    it('returns false when subscription status is SUSPENDED', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['id' => 'I-BW452GLLEP1G', 'status' => 'SUSPENDED']);
+
+        $provider = $mock->mockProvider();
+
+        expect($provider->isSubscriptionActive('I-BW452GLLEP1G'))->toBeFalse();
+    });
+
+    it('returns false when subscription status is CANCELLED', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['id' => 'I-BW452GLLEP1G', 'status' => 'CANCELLED']);
+
+        $provider = $mock->mockProvider();
+
+        expect($provider->isSubscriptionActive('I-BW452GLLEP1G'))->toBeFalse();
+    });
+
+    it('returns false when subscription status is EXPIRED', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['id' => 'I-BW452GLLEP1G', 'status' => 'EXPIRED']);
+
+        $provider = $mock->mockProvider();
+
+        expect($provider->isSubscriptionActive('I-BW452GLLEP1G'))->toBeFalse();
+    });
+
+    it('returns false when the API returns an error', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['error' => ['name' => 'RESOURCE_NOT_FOUND']], 404);
+
+        $provider = $mock->mockProvider();
+
+        expect($provider->isSubscriptionActive('I-INVALID'))->toBeFalse();
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `reactivateSubscription(string \$id, string \$reason = 'Reactivating subscription')` — convenience wrapper around the existing `activateSubscription()` for the common "resume after suspend" case; the reason parameter defaults to a sensible value so callers don't need to supply one
- Adds `isSubscriptionActive(string \$id): bool` — fetches subscription details and returns `true` only when `status === 'ACTIVE'`, avoiding manual status string comparisons in application code; returns `false` for all error, non-array, and non-ACTIVE responses

## Changes

| File | Change |
|------|--------|
| `src/Traits/PayPalAPI/Subscriptions.php` | Two new public methods |
| `tests/Unit/Adapter/SubscriptionLifecycleHelpersTest.php` | New — 7 tests using `MockPayPalClient` |
| `README.md` | Added lifecycle helper examples to the Subscriptions section |

## Test plan

- [ ] `reactivateSubscription` POSTs to `.../activate` with default reason `'Reactivating subscription'`
- [ ] `reactivateSubscription` POSTs with a custom reason when provided
- [ ] `isSubscriptionActive` returns `true` for `ACTIVE` status and hits the correct GET endpoint
- [ ] `isSubscriptionActive` returns `false` for `SUSPENDED`, `CANCELLED`, `EXPIRED`
- [ ] `isSubscriptionActive` returns `false` on API error (404)
- [ ] Full suite passes with no regressions (663 tests)
- [ ] PHPStan level 8 clean