### PR TITLE
feat: add WebhookEvent value object for typed webhook payload handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,6 +857,46 @@ $valid = $provider->verifyWebHookLocally(
 > processes (serverless, etc.) will still fetch the cert on each cold start. The cert URL is
 > validated against PayPal's known API domains before any request is made (SSRF guard).
 
+### Handling webhook events
+
+After verification, parse the raw body into a typed `WebhookEvent` and route by event type:
+
+```php
+use Srmklive\PayPal\Events\WebhookEvent;
+
+$rawBody = $request->getContent();
+
+if (! $provider->verifyWebHookLocally($request->headers->all(), 'your-webhook-id', $rawBody)) {
+    return response()->json(['error' => 'Invalid signature'], 401);
+}
+
+$event = WebhookEvent::fromRawBody($rawBody);
+
+if ($event->is('PAYMENT.CAPTURE.COMPLETED')) {
+    // $event->resource contains the capture object
+    $this->handleCapture($event->resource);
+}
+
+if ($event->is('BILLING.SUBSCRIPTION.CANCELLED')) {
+    $this->handleCancellation($event->resource);
+}
+
+// Available properties:
+// $event->id           — webhook notification ID
+// $event->eventType    — e.g. 'PAYMENT.CAPTURE.COMPLETED'
+// $event->resourceType — e.g. 'capture'
+// $event->summary      — human-readable summary
+// $event->createTime   — ISO 8601 timestamp
+// $event->resource     — event-specific resource array
+// $event->rawPayload   — full decoded payload array
+```
+
+You can also build from an already-decoded array:
+
+```php
+$event = WebhookEvent::fromArray($request->json()->all());
+```
+
 ---
 
 ## Payment Method Tokens

--- a/src/Events/WebhookEvent.php
+++ b/src/Events/WebhookEvent.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Srmklive\PayPal\Events;
+
+/**
+ * Typed value object wrapping an incoming PayPal webhook payload.
+ *
+ * Construct via the static factories rather than the constructor directly:
+ *
+ *   $event = WebhookEvent::fromRawBody($request->getContent());
+ *   $event = WebhookEvent::fromArray(json_decode($body, true));
+ */
+final class WebhookEvent
+{
+    /**
+     * @param array<string, mixed> $resource   The event-specific resource object.
+     * @param array<string, mixed> $rawPayload The full decoded payload.
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $eventType,
+        public readonly string $resourceType,
+        public readonly string $summary,
+        public readonly string $createTime,
+        public readonly array $resource,
+        public readonly array $rawPayload,
+    ) {}
+
+    /**
+     * Build a WebhookEvent from a decoded payload array.
+     *
+     * @param array<string, mixed> $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        /** @var array<string, mixed> $resource */
+        $resource = is_array($payload['resource'] ?? null) ? $payload['resource'] : [];
+
+        return new self(
+            id: (string) ($payload['id'] ?? ''),
+            eventType: (string) ($payload['event_type'] ?? ''),
+            resourceType: (string) ($payload['resource_type'] ?? ''),
+            summary: (string) ($payload['summary'] ?? ''),
+            createTime: (string) ($payload['create_time'] ?? ''),
+            resource: $resource,
+            rawPayload: $payload,
+        );
+    }
+
+    /**
+     * Build a WebhookEvent from a raw JSON request body string.
+     *
+     * Invalid JSON produces an empty event rather than throwing.
+     */
+    public static function fromRawBody(string $rawBody): self
+    {
+        $decoded = json_decode($rawBody, true);
+
+        return self::fromArray(is_array($decoded) ? $decoded : []);
+    }
+
+    /**
+     * Return true if this event's type matches the given string.
+     *
+     * Useful for routing without repeated property access:
+     *
+     *   if ($event->is('PAYMENT.CAPTURE.COMPLETED')) { ... }
+     */
+    public function is(string $eventType): bool
+    {
+        return $this->eventType === $eventType;
+    }
+}

--- a/tests/Unit/Events/WebhookEventTest.php
+++ b/tests/Unit/Events/WebhookEventTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use Srmklive\PayPal\Events\WebhookEvent;
+
+describe('WebhookEvent::fromArray', function () {
+    it('maps all fields from a full payload', function () {
+        $payload = [
+            'id'            => '8PT597110X687430LKGECATA',
+            'event_type'    => 'PAYMENT.CAPTURE.COMPLETED',
+            'resource_type' => 'capture',
+            'summary'       => 'Payment completed for $ 7.47 USD',
+            'create_time'   => '2021-01-01T12:00:00Z',
+            'resource'      => ['id' => 'CAP-123', 'amount' => ['value' => '7.47']],
+        ];
+
+        $event = WebhookEvent::fromArray($payload);
+
+        expect($event->id)->toBe('8PT597110X687430LKGECATA');
+        expect($event->eventType)->toBe('PAYMENT.CAPTURE.COMPLETED');
+        expect($event->resourceType)->toBe('capture');
+        expect($event->summary)->toBe('Payment completed for $ 7.47 USD');
+        expect($event->createTime)->toBe('2021-01-01T12:00:00Z');
+        expect($event->resource)->toBe(['id' => 'CAP-123', 'amount' => ['value' => '7.47']]);
+        expect($event->rawPayload)->toBe($payload);
+    });
+
+    it('defaults missing fields to empty strings', function () {
+        $event = WebhookEvent::fromArray([]);
+
+        expect($event->id)->toBe('');
+        expect($event->eventType)->toBe('');
+        expect($event->resourceType)->toBe('');
+        expect($event->summary)->toBe('');
+        expect($event->createTime)->toBe('');
+        expect($event->resource)->toBe([]);
+    });
+
+    it('defaults resource to empty array when absent', function () {
+        $event = WebhookEvent::fromArray(['event_type' => 'PAYMENT.CAPTURE.COMPLETED']);
+
+        expect($event->resource)->toBe([]);
+    });
+
+    it('defaults resource to empty array when not an array', function () {
+        $event = WebhookEvent::fromArray(['resource' => 'invalid']);
+
+        expect($event->resource)->toBe([]);
+    });
+
+    it('preserves the full rawPayload', function () {
+        $payload = ['event_type' => 'BILLING.SUBSCRIPTION.CANCELLED', 'custom_field' => 'abc'];
+
+        $event = WebhookEvent::fromArray($payload);
+
+        expect($event->rawPayload)->toBe($payload);
+    });
+});
+
+describe('WebhookEvent::fromRawBody', function () {
+    it('parses a valid JSON body', function () {
+        $body = json_encode([
+            'id'         => 'EVT-001',
+            'event_type' => 'PAYMENT.AUTHORIZATION.CREATED',
+            'resource'   => ['id' => 'AUTH-123'],
+        ]);
+
+        $event = WebhookEvent::fromRawBody($body);
+
+        expect($event->id)->toBe('EVT-001');
+        expect($event->eventType)->toBe('PAYMENT.AUTHORIZATION.CREATED');
+        expect($event->resource)->toBe(['id' => 'AUTH-123']);
+    });
+
+    it('returns an empty event for invalid JSON without throwing', function () {
+        $event = WebhookEvent::fromRawBody('not-json-at-all');
+
+        expect($event->id)->toBe('');
+        expect($event->eventType)->toBe('');
+        expect($event->resource)->toBe([]);
+    });
+
+    it('returns an empty event for an empty string', function () {
+        $event = WebhookEvent::fromRawBody('');
+
+        expect($event->eventType)->toBe('');
+    });
+
+    it('returns an empty event when JSON is not an object', function () {
+        $event = WebhookEvent::fromRawBody('"just-a-string"');
+
+        expect($event->eventType)->toBe('');
+    });
+});
+
+describe('WebhookEvent::is', function () {
+    it('returns true when the event type matches', function () {
+        $event = WebhookEvent::fromArray(['event_type' => 'PAYMENT.CAPTURE.COMPLETED']);
+
+        expect($event->is('PAYMENT.CAPTURE.COMPLETED'))->toBeTrue();
+    });
+
+    it('returns false when the event type does not match', function () {
+        $event = WebhookEvent::fromArray(['event_type' => 'PAYMENT.CAPTURE.COMPLETED']);
+
+        expect($event->is('BILLING.SUBSCRIPTION.CANCELLED'))->toBeFalse();
+    });
+
+    it('is case-sensitive', function () {
+        $event = WebhookEvent::fromArray(['event_type' => 'PAYMENT.CAPTURE.COMPLETED']);
+
+        expect($event->is('payment.capture.completed'))->toBeFalse();
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `WebhookEvent` (`src/Events/WebhookEvent.php`) — a `final` class with `readonly` properties that wraps an incoming PayPal webhook payload in a typed value object
- `WebhookEvent::fromRawBody(string $rawBody): self` — parses a raw JSON request body; invalid/empty JSON returns an empty event without throwing
- `WebhookEvent::fromArray(array $payload): self` — constructs from an already-decoded payload array with safe defaults for all missing fields
- `WebhookEvent::is(string $eventType): bool` — quick event-type check for clean routing without repeated `$event->eventType === '...'` comparisons
- Updates README with a "Handling webhook events" subsection showing the full verify → parse → route workflow

## Changes

| File | Change |
|------|--------|
| `src/Events/WebhookEvent.php` | New — typed value object |
| `tests/Unit/Events/WebhookEventTest.php` | New — 12 unit tests |
| `README.md` | New "Handling webhook events" subsection under Webhooks |

## Test plan

- [ ] `fromArray` maps all fields from a full payload correctly
- [ ] `fromArray` defaults all fields to empty strings/arrays when payload is empty
- [ ] `fromArray` defaults `resource` to `[]` when key is absent or not an array
- [ ] `fromArray` preserves the full `rawPayload`
- [ ] `fromRawBody` parses valid JSON and maps fields
- [ ] `fromRawBody` returns an empty event for invalid JSON, empty string, and non-object JSON without throwing
- [ ] `is()` returns true on exact match, false on mismatch and wrong case
- [ ] Full suite passes with no regressions (684 tests)
- [ ] PHPStan level 8 clean