### PR TITLE
feat: add setPartnerAttributionId() convenience method

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,16 @@ $provider->getAccessToken();
 $provider->setCurrency('EUR');
 ```
 
+### Partner Attribution ID (BN code)
+
+PayPal uses the `PayPal-Partner-Attribution-Id` header to attribute transactions to a partner or platform. Set it once after initialisation — it persists for the lifetime of the provider instance:
+
+```php
+$provider->setPartnerAttributionId('YourPlatform_SP');
+```
+
+All subsequent API calls will include the header automatically.
+
 ### Error Handling
 
 By default, API errors are returned as an array with an `error` key:

--- a/src/Traits/PayPalRequest.php
+++ b/src/Traits/PayPalRequest.php
@@ -123,6 +123,22 @@ trait PayPalRequest
     }
 
     /**
+     * Set the PayPal-Partner-Attribution-Id (BN code) for all subsequent requests.
+     *
+     * PayPal uses this header to attribute transactions to a partner or platform.
+     * Unlike the idempotency key, this header persists for the lifetime of the
+     * provider instance — set it once after initialisation.
+     *
+     * @see https://developer.paypal.com/docs/api/reference/api-requests/#http-request-headers
+     */
+    public function setPartnerAttributionId(string $id): static
+    {
+        $this->setRequestHeader('PayPal-Partner-Attribution-Id', $id);
+
+        return $this;
+    }
+
+    /**
      * Set a PayPal-Request-Id idempotency key for the next request.
      *
      * Sending this header allows safe retrying of failed requests without

--- a/tests/Feature/AdapterPartnerAttributionIdTest.php
+++ b/tests/Feature/AdapterPartnerAttributionIdTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Srmklive\PayPal\Services\PayPal as PayPalClient;
+use Srmklive\PayPal\Testing\MockPayPalClient;
+use Srmklive\PayPal\Tests\MockRequestPayloads;
+use Srmklive\PayPal\Tests\MockResponsePayloads;
+
+uses(MockRequestPayloads::class, MockResponsePayloads::class);
+
+beforeEach(function () {
+    $this->client = new PayPalClient($this->getApiCredentials());
+    $this->client->setClient($this->mock_http_client($this->mockAccessTokenResponse()));
+    $response = $this->client->getAccessToken();
+    $this->access_token = $response['access_token'];
+});
+
+it('setPartnerAttributionId is fluent', function () {
+    $result = $this->client->setPartnerAttributionId('TestPlatform_SP');
+
+    expect($result)->toBeInstanceOf(PayPalClient::class);
+});
+
+it('setPartnerAttributionId sets the correct header value', function () {
+    $this->client->setPartnerAttributionId('TestPlatform_SP');
+
+    expect($this->client->getRequestHeader('PayPal-Partner-Attribution-Id'))->toBe('TestPlatform_SP');
+});
+
+it('partner attribution id persists across multiple requests', function () {
+    $mock = new MockPayPalClient();
+    $mock->addResponse(['id' => 'ORDER-1', 'status' => 'CREATED']);
+    $mock->addResponse(['id' => 'ORDER-2', 'status' => 'CREATED']);
+
+    $provider = $mock->mockProvider();
+    $provider->setPartnerAttributionId('MyPlatform_BN');
+
+    $provider->createOrder($this->createOrderParams());
+    expect($mock->requests()[0]->getHeaderLine('PayPal-Partner-Attribution-Id'))->toBe('MyPlatform_BN');
+
+    $provider->createOrder($this->createOrderParams());
+    expect($mock->requests()[1]->getHeaderLine('PayPal-Partner-Attribution-Id'))->toBe('MyPlatform_BN');
+});


### PR DESCRIPTION
## Summary

- Adds `setPartnerAttributionId(string \$id): static` to `PayPalRequest` — a fluent named wrapper around `setRequestHeader('PayPal-Partner-Attribution-Id', \$id)`
- Unlike the idempotency key, the attribution ID is **not** cleared after each request — it persists for the lifetime of the provider instance so partners set it once after initialisation and all subsequent calls carry the header automatically
- Updates README with a "Partner Attribution ID (BN code)" subsection

## Changes

| File | Change |
|------|--------|
| `src/Traits/PayPalRequest.php` | New `setPartnerAttributionId()` method |
| `tests/Feature/AdapterPartnerAttributionIdTest.php` | New — 3 tests (fluent, header value, persistence across requests) |
| `README.md` | New "Partner Attribution ID" subsection under Usage |

## Test plan

- [ ] `setPartnerAttributionId()` returns `$this` (fluent)
- [ ] Sets `PayPal-Partner-Attribution-Id` header to the supplied value
- [ ] Header is present on the first and second request after a single `setPartnerAttributionId()` call (persistence)
- [ ] Full suite passes with no regressions (682 tests)
- [ ] PHPStan level 8 clean