### PR TITLE
feat: add transaction detail lookup and filter-preset helpers to Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,10 +937,19 @@ $response = $provider->setTokenSource('5C991763VB2781612', 'SETUP_TOKEN')
 ```php
 use Carbon\Carbon;
 
+// Raw filter array (full control)
 $provider->listTransactions([
-    'start_date' => Carbon::now()->toIso8601String(),
-    'end_date'   => Carbon::now()->addDays(30)->toIso8601String(),
+    'start_date' => Carbon::now()->subDays(30)->toIso8601String(),
+    'end_date'   => Carbon::now()->toIso8601String(),
 ]);
+
+// Convenience helpers
+$provider->getTransactionDetails('5TY05013RG002845M');        // searches last 31 days
+$provider->getTransactionDetails('5TY05013RG002845M', 7);    // searches last 7 days
+
+$provider->listTransactionsForDateRange('2024-07-01', '2024-07-31');
+$provider->listTransactionsByType('T0006', '2024-07-01', '2024-07-31'); // e.g. express checkout sales
+$provider->listTransactionsByStatus('S', '2024-07-01', '2024-07-31');  // 'S'=success, 'V'=reversed, 'P'=pending
 
 $provider->listBalances('2024-01-01');
 $provider->listBalances('2024-01-01', 'EUR');

--- a/src/Traits/PayPalAPI/Reporting.php
+++ b/src/Traits/PayPalAPI/Reporting.php
@@ -32,6 +32,104 @@ trait Reporting
     }
 
     /**
+     * Get details for a specific transaction by its ID.
+     *
+     * Searches the last $daysBack days (max 31, the PayPal API limit). Returns
+     * the first matching entry from transaction_details, or null if not found
+     * or if the API returns an error.
+     *
+     * @return array<string, mixed>|null
+     *
+     * @throws \Throwable
+     *
+     * @see https://developer.paypal.com/docs/api/transaction-search/v1/#transactions_get
+     */
+    public function getTransactionDetails(string $transactionId, int $daysBack = 31): ?array
+    {
+        $daysBack = max(1, min($daysBack, 31));
+
+        $response = $this->listTransactions([
+            'transaction_id' => $transactionId,
+            'start_date'     => Carbon::now()->subDays($daysBack)->toIso8601ZuluString(),
+            'end_date'       => Carbon::now()->toIso8601ZuluString(),
+        ]);
+
+        if (! is_array($response)) {
+            return null;
+        }
+
+        $details = $response['transaction_details'] ?? [];
+
+        return is_array($details) && count($details) > 0 ? $details[0] : null;
+    }
+
+    /**
+     * List transactions within a date range without additional filters.
+     *
+     * @param  \DateTimeInterface|string  $startDate
+     * @param  \DateTimeInterface|string  $endDate
+     *
+     * @return array<string, mixed>|StreamInterface|string
+     *
+     * @throws \Throwable
+     */
+    public function listTransactionsForDateRange(\DateTimeInterface|string $startDate, \DateTimeInterface|string $endDate, string $fields = 'all'): array|StreamInterface|string
+    {
+        return $this->listTransactions([
+            'start_date' => Carbon::parse($startDate)->toIso8601ZuluString(),
+            'end_date'   => Carbon::parse($endDate)->toIso8601ZuluString(),
+        ], $fields);
+    }
+
+    /**
+     * List transactions filtered by transaction event code.
+     *
+     * Common codes: 'T0006' (express checkout payment), 'T0001' (general payment),
+     * 'T1107' (payment refund). See PayPal docs for the full list.
+     *
+     * @param  \DateTimeInterface|string  $startDate
+     * @param  \DateTimeInterface|string  $endDate
+     *
+     * @return array<string, mixed>|StreamInterface|string
+     *
+     * @throws \Throwable
+     *
+     * @see https://developer.paypal.com/docs/transaction-search/transaction-event-codes/
+     */
+    public function listTransactionsByType(string $transactionType, \DateTimeInterface|string $startDate, \DateTimeInterface|string $endDate): array|StreamInterface|string
+    {
+        return $this->listTransactions([
+            'transaction_type' => $transactionType,
+            'start_date'       => Carbon::parse($startDate)->toIso8601ZuluString(),
+            'end_date'         => Carbon::parse($endDate)->toIso8601ZuluString(),
+        ]);
+    }
+
+    /**
+     * List transactions filtered by status code.
+     *
+     * Common codes: 'S' (success), 'V' (reversed/cancelled), 'P' (pending),
+     * 'D' (denied), 'F' (partially refunded).
+     *
+     * @param  \DateTimeInterface|string  $startDate
+     * @param  \DateTimeInterface|string  $endDate
+     *
+     * @return array<string, mixed>|StreamInterface|string
+     *
+     * @throws \Throwable
+     *
+     * @see https://developer.paypal.com/docs/transaction-search/transaction-statuses/
+     */
+    public function listTransactionsByStatus(string $transactionStatus, \DateTimeInterface|string $startDate, \DateTimeInterface|string $endDate): array|StreamInterface|string
+    {
+        return $this->listTransactions([
+            'transaction_status' => $transactionStatus,
+            'start_date'         => Carbon::parse($startDate)->toIso8601ZuluString(),
+            'end_date'           => Carbon::parse($endDate)->toIso8601ZuluString(),
+        ]);
+    }
+
+    /**
      * List available balance.
      *
      *

--- a/tests/Unit/Adapter/ReportingHelpersTest.php
+++ b/tests/Unit/Adapter/ReportingHelpersTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use Srmklive\PayPal\Testing\MockPayPalClient;
+use Srmklive\PayPal\Tests\MockResponsePayloads;
+
+uses(MockResponsePayloads::class);
+
+// ── getTransactionDetails ─────────────────────────────────────────────────────
+
+describe('getTransactionDetails', function () {
+    it('returns the first transaction detail entry when found', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse($this->mockListTransactionsResponse());
+
+        $provider = $mock->mockProvider();
+        $result = $provider->getTransactionDetails('5TY05013RG002845M');
+
+        expect($result)->toBeArray();
+        expect($result['transaction_info']['transaction_id'])->toBe('5TY05013RG002845M');
+        expect($mock->lastRequest()->getMethod())->toBe('GET');
+        expect((string) $mock->lastRequest()->getUri())->toContain('v1/reporting/transactions');
+        expect((string) $mock->lastRequest()->getUri())->toContain('transaction_id=5TY05013RG002845M');
+    });
+
+    it('returns null when transaction_details is empty', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['transaction_details' => [], 'total_items' => 0]);
+
+        $provider = $mock->mockProvider();
+
+        expect($provider->getTransactionDetails('NONEXISTENT'))->toBeNull();
+    });
+
+    it('returns null when the API returns an error', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['error' => 'INVALID_REQUEST'], 400);
+
+        $provider = $mock->mockProvider();
+
+        expect($provider->getTransactionDetails('BAD-ID'))->toBeNull();
+    });
+
+    it('clamps daysBack to the 1–31 range', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse(['transaction_details' => [], 'total_items' => 0]);
+
+        $provider = $mock->mockProvider();
+        $provider->getTransactionDetails('TXN-123', 999);
+
+        // Should not throw; URL will contain start_date based on 31 days back
+        expect($mock->requestCount())->toBe(1);
+    });
+});
+
+// ── listTransactionsForDateRange ──────────────────────────────────────────────
+
+describe('listTransactionsForDateRange', function () {
+    it('calls listTransactions with start_date and end_date and returns the response', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse($this->mockListTransactionsResponse());
+
+        $provider = $mock->mockProvider();
+        $result = $provider->listTransactionsForDateRange('2024-07-01', '2024-07-31');
+
+        expect($result)->toHaveKey('transaction_details');
+        expect($mock->lastRequest()->getMethod())->toBe('GET');
+
+        $uri = (string) $mock->lastRequest()->getUri();
+        expect($uri)->toContain('v1/reporting/transactions');
+        expect($uri)->toContain('start_date=');
+        expect($uri)->toContain('end_date=');
+    });
+
+    it('accepts DateTimeInterface arguments', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse($this->mockListTransactionsResponse());
+
+        $provider = $mock->mockProvider();
+        $result = $provider->listTransactionsForDateRange(
+            new \DateTime('2024-07-01'),
+            new \DateTime('2024-07-31'),
+        );
+
+        expect($result)->toHaveKey('transaction_details');
+    });
+});
+
+// ── listTransactionsByType ────────────────────────────────────────────────────
+
+describe('listTransactionsByType', function () {
+    it('includes transaction_type in the query string', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse($this->mockListTransactionsResponse());
+
+        $provider = $mock->mockProvider();
+        $provider->listTransactionsByType('T0006', '2024-07-01', '2024-07-31');
+
+        expect((string) $mock->lastRequest()->getUri())->toContain('transaction_type=T0006');
+    });
+});
+
+// ── listTransactionsByStatus ──────────────────────────────────────────────────
+
+describe('listTransactionsByStatus', function () {
+    it('includes transaction_status in the query string', function () {
+        $mock = new MockPayPalClient();
+        $mock->addResponse($this->mockListTransactionsResponse());
+
+        $provider = $mock->mockProvider();
+        $provider->listTransactionsByStatus('S', '2024-07-01', '2024-07-31');
+
+        expect((string) $mock->lastRequest()->getUri())->toContain('transaction_status=S');
+    });
+});


### PR DESCRIPTION
## Summary

Extends the `Reporting` trait with four convenience helpers that sit on top of the existing `listTransactions()`:

- **`getTransactionDetails(string \$id, int \$daysBack = 31): ?array`** — looks up a single transaction by ID; searches the last N days (clamped to PayPal's 31-day max), returns the first `transaction_details` entry or `null` when not found / on error
- **`listTransactionsForDateRange(\$start, \$end, string \$fields = 'all')`** — plain date-range shortcut without needing to build the filter array manually; accepts `DateTimeInterface|string`
- **`listTransactionsByType(string \$type, \$start, \$end)`** — filters by transaction event code (e.g. `T0006` for express checkout sales, `T1107` for refunds)
- **`listTransactionsByStatus(string \$status, \$start, \$end)`** — filters by status code (`S`=success, `V`=reversed, `P`=pending, `D`=denied, `F`=partially refunded)

## Changes

| File | Change |
|------|--------|
| `src/Traits/PayPalAPI/Reporting.php` | Four new public methods |
| `tests/Unit/Adapter/ReportingHelpersTest.php` | New — 8 tests using `MockPayPalClient` |
| `README.md` | Updated Reporting section with convenience helper examples |

## Test plan

- [ ] `getTransactionDetails` returns the first `transaction_details` entry and hits the correct endpoint with `transaction_id` in the query string
- [ ] `getTransactionDetails` returns `null` for empty results and API errors
- [ ] `getTransactionDetails` clamps `daysBack` to the 1–31 range without throwing
- [ ] `listTransactionsForDateRange` passes `start_date`/`end_date` and accepts both string and `DateTimeInterface`
- [ ] `listTransactionsByType` includes `transaction_type` in the query string
- [ ] `listTransactionsByStatus` includes `transaction_status` in the query string
- [ ] Full suite passes with no regressions (699 tests)
- [ ] PHPStan level 8 clean