### PR TITLE
feat: add Pay Upon Invoice (BNPL) payment source helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A PayPal REST API package for Laravel, also usable as a standalone PHP client wi
 - [Configuration](#configuration)
 - [Usage](#usage)
 - [PayPal Fastlane](#paypal-fastlane)
+- [Pay Upon Invoice (Buy Now, Pay Later — DE/AT)](#pay-upon-invoice-buy-now-pay-later--deat)
 - [Subscription Helpers](#subscription-helpers)
 - [Billing Plans](#billing-plans)
   - [BillingPlanBuilder](#billingplanbuilder)
@@ -395,6 +396,45 @@ $capture = $provider->capturePaymentOrder($order['id']);
 
 // Extract the transaction/capture ID
 $captureId = $provider->getCaptureIdFromOrder($capture);
+```
+
+---
+
+## Pay Upon Invoice (Buy Now, Pay Later — DE/AT)
+
+[Pay Upon Invoice](https://developer.paypal.com/docs/checkout/pay-upon-invoice/) (Rechnungskauf) lets buyers in Germany and Austria pay after receiving goods. PayPal collects the payment and the merchant is paid upfront.
+
+**Requirements:** DE/AT merchant account, buyer name, email, date of birth, phone number, and billing address.
+
+```php
+$provider->getAccessToken();
+
+$provider->setPaymentSourcePayUponInvoice([
+    'name'       => ['given_name' => 'John', 'surname' => 'Doe'],
+    'email'      => 'john.doe@example.com',
+    'birth_date' => '1990-01-01',
+    'phone'      => ['country_code' => '49', 'national_number' => '1234567890'],
+    'billing_address' => [
+        'address_line_1' => 'Hauptstraße 1',
+        'admin_area_2'   => 'Berlin',
+        'postal_code'    => '10115',
+        'country_code'   => 'DE',
+    ],
+    'experience_context' => [
+        'locale'     => 'de-DE',
+        'return_url' => 'https://example.com/paypal-success',
+        'cancel_url' => 'https://example.com/paypal-cancel',
+    ],
+]);
+
+$order = $provider->createOrderWithPaymentSource([
+    'intent'         => 'CAPTURE',
+    'purchase_units' => [
+        ['amount' => ['currency_code' => 'EUR', 'value' => '99.00']],
+    ],
+]);
+
+$capture = $provider->capturePaymentOrder($order['id']);
 ```
 
 ---

--- a/src/Traits/PayPalAPI/PaymentMethodsTokens/Helpers.php
+++ b/src/Traits/PayPalAPI/PaymentMethodsTokens/Helpers.php
@@ -122,6 +122,22 @@ trait Helpers
     }
 
     /**
+     * Set payment source data for Pay Upon Invoice (Rechnungskauf).
+     *
+     * Available for DE/AT merchants only. The $data array must include the
+     * buyer's name, email, birth_date, phone, and billing_address. An
+     * experience_context (locale, return_url, cancel_url) is recommended.
+     *
+     * @param array<string, mixed> $data
+     *
+     * @see https://developer.paypal.com/docs/checkout/pay-upon-invoice/
+     */
+    public function setPaymentSourcePayUponInvoice(array $data): PayPal
+    {
+        return $this->setPaymentSourceDetails('pay_upon_invoice', $data);
+    }
+
+    /**
      * Set billing address for the card payment source (ACDC / unbranded card).
      *
      * Merges into any existing payment_source.card data set by setPaymentSourceCard().

--- a/tests/Unit/Helpers/PaymentMethodsTokensHelpersTest.php
+++ b/tests/Unit/Helpers/PaymentMethodsTokensHelpersTest.php
@@ -56,6 +56,22 @@ it('setPaymentSourceGooglePay sets google_pay as payment source', function () {
     expect($client->getPaymentSource())->toBe(['google_pay' => $data]);
 });
 
+it('setPaymentSourcePayUponInvoice sets pay_upon_invoice as payment source', function () {
+    $client = $this->createPartialMock(PayPalClient::class, []);
+    $data   = [
+        'name'            => ['given_name' => 'John', 'surname' => 'Doe'],
+        'email'           => 'john.doe@example.com',
+        'birth_date'      => '1990-01-01',
+        'phone'           => ['country_code' => '49', 'national_number' => '1234567890'],
+        'billing_address' => ['address_line_1' => 'Hauptstraße 1', 'admin_area_2' => 'Berlin', 'postal_code' => '10115', 'country_code' => 'DE'],
+    ];
+
+    $result = $client->setPaymentSourcePayUponInvoice($data);
+
+    expect($result)->toBeInstanceOf(PayPalClient::class);
+    expect($client->getPaymentSource())->toBe(['pay_upon_invoice' => $data]);
+});
+
 it('setTokenSource sets token as payment source', function () {
     $client = $this->createPartialMock(PayPalClient::class, []);
 


### PR DESCRIPTION
## Summary

- Adds `setPaymentSourcePayUponInvoice(array $data): PayPal` to the payment source helpers, following the same pattern as `setPaymentSourceCard()`, `setPaymentSourceApplePay()`, etc.
- Sets `payment_source.pay_upon_invoice` — compatible with `createOrderWithPaymentSource()` and the existing experience_context merging logic.
- Adds one unit test covering the happy path; all 695 existing tests continue to pass.
- Documents the Pay Upon Invoice flow in README with a full server-side code example.

## API reference

[PayPal Pay Upon Invoice](https://developer.paypal.com/docs/checkout/pay-upon-invoice/) — available for DE/AT merchants only.

## Test plan

- [x] `./vendor/bin/phpstan analyse src/ --memory-limit=512M` — no errors
- [x] `./vendor/bin/pest` — 695 passed, 0 failures